### PR TITLE
Fix the path for pscopehat controller log files

### DIFF
--- a/control/pscopehat/main.py
+++ b/control/pscopehat/main.py
@@ -17,7 +17,7 @@ import planktoscope.display # Fan HAT OLED screen
 # rotation happens everyday at 01:00 if not restarted
 logger.add(
     # sys.stdout,
-    "PlanktoScope_{time}.log",
+    "/home/pi/device-backend-logs/control/{time}.log",
     rotation="5 MB",
     retention="1 week",
     compression=".tar.gz",


### PR DESCRIPTION
This PR updates the pscopehat version of the controller to save its log files to the same location as the adafruithat version of the controller.