### PR TITLE
Fix white balance keys in the default hardware config for v2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.MM.patch` scheme
+for all releases after `v2.3.0`.
+All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
+
+## Unreleased
+
+### Changed
+
+- Split the Python backend into a hardware controller (of which there are two versions for the Adafruit HAT and the custom PlanktoScope HAT, respectively) and a data processing segmenter. These two components are run separately, and their dependencies are managed separately.
+- Each component of the backend now saves its file logs to its respective folder in `/home/pi/device-backend`.
+
+### Fixed
+
+- The default `hardware.json` file for PlanktoScope v2.1 had incorrect keys for the white balance values; the keys have now been fixed.

--- a/default-configs/adafruithat-latest.hardware.json
+++ b/default-configs/adafruithat-latest.hardware.json
@@ -6,8 +6,8 @@
   "focus_max_speed": 0.5,
   "pump_max_speed": 30,
   "stepper_type": "adafruit",
-  "wb_red_gain": 2,
-  "wb_blue_gain": 1.41,
+  "red_gain": 2,
+  "blue_gain": 1.41,
   "analog_gain": 1.0,
   "digital_gain": 1.0,
   "acq_fnumber_objective": 16

--- a/default-configs/v2.1.hardware.json
+++ b/default-configs/v2.1.hardware.json
@@ -6,8 +6,8 @@
   "focus_max_speed": 0.5,
   "pump_max_speed": 30,
   "stepper_type": "adafruit",
-  "wb_red_gain": 2,
-  "wb_blue_gain": 1.41,
+  "red_gain": 2,
+  "blue_gain": 1.41,
   "analog_gain": 1.0,
   "digital_gain": 1.0,
   "acq_fnumber_objective": 16


### PR DESCRIPTION
The default `hardware.json` file for PlanktoScope v2.1 had incorrect keys for the white balance values - the names were `wb_red_gain` and `wb_blue_gain`, when they should've been `red_gain` and `blue_gain`. This PR changes those keys to their correct names.