### PR TITLE
Bump version numbers for v2023.9.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.MM.patch` scheme
-for all releases after `v2.3.0`.
+and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.MM.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
 ## Unreleased
+
+## v2023.9.0-beta.0 - 2023-09-02
 
 ### Changed
 


### PR DESCRIPTION
This PR updates `CHANGELOG.md` so that we can add a prerelease tag at v2023.9.0-beta.0.