### PR TITLE
Use the new machine naming scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Changed
+
+- The machine name has been switched to the new naming scheme provided by https://github.com/PlanktoScope/machine-name ; the machine name is loaded from a file (currently at `/home/pi/.local/etc/machine-name`, which must be automatically generaed by the host operating system) instead of being determined in Python.
+
+### Deprecated
+
+- The old "Baba"-based machine naming scheme should no longer be used. The `uuidName` module will be removed the next stable release (the stable release after v2023.9.0).
+
 ## v2023.9.0-beta.0 - 2023-09-02
 
 ### Changed

--- a/control/adafruithat/main.py
+++ b/control/adafruithat/main.py
@@ -27,7 +27,8 @@ import planktoscope.mqtt
 import planktoscope.stepper
 import planktoscope.imager
 import planktoscope.light # Fan HAT LEDs
-import planktoscope.uuidName # TODO: replace this with the new system-level machinename
+import planktoscope.identity
+import planktoscope.uuidName # Note: this is deprecated.
 import planktoscope.display # Fan HAT OLED screen
 
 # enqueue=True is necessary so we can log accross modules
@@ -92,9 +93,12 @@ if __name__ == "__main__":
         # create the path!
         os.makedirs(img_path)
 
-    logger.info(f"This PlanktoScope unique ID is {planktoscope.uuidName.getSerial()}")
+    logger.info(f"This PlanktoScope's Raspberry Pi's serial number is {planktoscope.uuidName.getSerial()}")
     logger.info(
-        f"This PlanktoScope unique name is {planktoscope.uuidName.machineName(machine=planktoscope.uuidName.getSerial())}"
+        f"This PlanktoScope's machine name is {planktoscope.identity.load_machine_name()}"
+    )
+    logger.info(
+        f"This PlanktoScope's deprecated name is {planktoscope.uuidName.machineName(machine=planktoscope.uuidName.getSerial())}"
     )
 
     # Prepare the event for a graceful shutdown

--- a/control/adafruithat/planktoscope/display.py
+++ b/control/adafruithat/planktoscope/display.py
@@ -29,7 +29,7 @@ import PIL.ImageFont
 
 logger.info("planktoscope.display is loading")
 
-import planktoscope.uuidName
+import planktoscope.identity
 
 
 class Display(object):
@@ -54,9 +54,7 @@ class Display(object):
     def display_machine_name(self):
         if self.display_available:
             self.__clear()
-            machineName = planktoscope.uuidName.machineName(
-                machine=planktoscope.uuidName.getSerial()
-            )
+            machineName = planktoscope.identity.load_machine_name()
             self.display_text(machineName.replace(" ", "\n"))
 
     def display_text(self, message):

--- a/control/adafruithat/planktoscope/identity.py
+++ b/control/adafruithat/planktoscope/identity.py
@@ -1,0 +1,11 @@
+# TODO: keep this as the default path, but allow changing it with an environment variable
+MACHINE_NAME_PATH = '/home/pi/.local/etc/machine-name'
+
+def load_machine_name(path=MACHINE_NAME_PATH):
+    """Returns the machine name specified by the file at MACHINE_NAMEPATH.
+
+    Returns:
+        str: the machine name stored in the file at the path.
+    """
+    with open(path, encoding='utf-8') as file:
+        return file.readline().strip()

--- a/control/adafruithat/planktoscope/imager/__init__.py
+++ b/control/adafruithat/planktoscope/imager/__init__.py
@@ -15,52 +15,25 @@
 # You should have received a copy of the GNU General Public License
 # along with PlanktoScope.  If not, see <http://www.gnu.org/licenses/>.
 
-################################################################################
-# Practical Libraries
-################################################################################
-
-# Logger library compatible with multiprocessing
-from loguru import logger
-
-# Library to get date and time for folder name and filename
-import datetime
-
-# Library to be able to sleep for a given duration
-import time
-
-# Libraries manipulate json format, execute bash commands
+import datetime # needed to get date and time for folder name and filename
+import time # needed to able to sleep for a given duration
 import json
-
-# Library for path and filesystem manipulations
 import os
 import shutil
-
-# Library for starting processes
 import multiprocessing
+import threading # needed for the streaming server
+import functools # needed for the streaming server
 
-# Basic planktoscope libraries
+from loguru import logger
+
+
 import planktoscope.mqtt
 import planktoscope.light
-
-# import planktoscope.streamer
 import planktoscope.imager.state_machine
-
-# import raspimjpeg module
 import planktoscope.imager.raspimjpeg
-
-# import streamer module
 import planktoscope.imager.streamer
-
-# Integrity verification module
 import planktoscope.integrity
-
-# Uuid module
-import planktoscope.uuidName
-
-
-# Libraries for the streaming server
-import threading
-import functools
+import planktoscope.identity
 
 
 logger.info("planktoscope.imager is loaded")
@@ -548,12 +521,8 @@ class ImagerProcess(multiprocessing.Process):
             "acq_camera_resolution": f"{self.__resolution[0]}x{self.__resolution[1]}",
             "acq_camera_iso": self.__iso,
             "acq_camera_shutter_speed": self.__shutter_speed,
-            "acq_uuid": planktoscope.uuidName.uuidMachine(
-                machine=planktoscope.uuidName.getSerial()
-            ),
-            "sample_uuid": planktoscope.uuidName.uuidMachine(
-                machine=planktoscope.uuidName.getSerial()
-            ),
+            "acq_uuid": planktoscope.identity.load_machine_name(),
+            "sample_uuid": planktoscope.identity.load_machine_name(),
         }
 
         # Concat the local metadata and the metadata from Node-RED

--- a/control/pscopehat/main.py
+++ b/control/pscopehat/main.py
@@ -10,7 +10,8 @@ import planktoscope.mqtt
 import planktoscope.stepper
 import planktoscope.imager
 import planktoscope.light # Fan HAT LEDs
-import planktoscope.uuidName # TODO: replace this with the new system-level machinename
+import planktoscope.identity
+import planktoscope.uuidName # Note: this is deprecated.
 import planktoscope.display # Fan HAT OLED screen
 
 # enqueue=True is necessary so we can log accross modules
@@ -74,9 +75,12 @@ if __name__ == "__main__":
         # create the path!
         os.makedirs(img_path)
 
-    logger.info(f"This PlanktoScope unique ID is {planktoscope.uuidName.getSerial()}")
+    logger.info(f"This PlanktoScope's Raspberry Pi's serial number is {planktoscope.uuidName.getSerial()}")
     logger.info(
-        f"This PlanktoScope unique name is {planktoscope.uuidName.machineName(machine=planktoscope.uuidName.getSerial())}"
+        f"This PlanktoScope's machine name is {planktoscope.identity.load_machine_name()}"
+    )
+    logger.info(
+        f"This PlanktoScope's deprecated name is {planktoscope.uuidName.machineName(machine=planktoscope.uuidName.getSerial())}"
     )
 
     # Prepare the event for a gracefull shutdown

--- a/control/pscopehat/planktoscope/display.py
+++ b/control/pscopehat/planktoscope/display.py
@@ -12,7 +12,7 @@ import PIL.ImageFont
 
 logger.info("planktoscope.display is loading")
 
-import planktoscope.uuidName
+import planktoscope.identity
 
 
 class Display(object):
@@ -37,9 +37,7 @@ class Display(object):
     def display_machine_name(self):
         if self.display_available:
             self.__clear()
-            machineName = planktoscope.uuidName.machineName(
-                machine=planktoscope.uuidName.getSerial()
-            )
+            machineName = planktoscope.identity.load_machine_name()
             self.display_text(machineName.replace(" ", "\n"))
 
     def display_text(self, message):

--- a/control/pscopehat/planktoscope/identity.py
+++ b/control/pscopehat/planktoscope/identity.py
@@ -1,0 +1,11 @@
+# TODO: keep this as the default path, but allow changing it with an environment variable
+MACHINE_NAME_PATH = '/home/pi/.local/etc/machine-name'
+
+def load_machine_name(path=MACHINE_NAME_PATH):
+    """Returns the machine name specified by the file at MACHINE_NAMEPATH.
+
+    Returns:
+        str: the machine name stored in the file at the path.
+    """
+    with open(path, encoding='utf-8') as file:
+        return file.readline().strip()

--- a/control/pscopehat/planktoscope/imager/__init__.py
+++ b/control/pscopehat/planktoscope/imager/__init__.py
@@ -1,48 +1,20 @@
-################################################################################
-# Practical Libraries
-################################################################################
-
-# Logger library compatible with multiprocessing
-from loguru import logger
-
-# Library to get date and time for folder name and filename
-import datetime
-
-# Library to be able to sleep for a given duration
-import time
-
-# Libraries manipulate json format, execute bash commands
+import datetime # needed to get date and time for folder name and filename
+import time # needed to able to sleep for a given duration
 import json
-
-# Library for path and filesystem manipulations
 import os
 import shutil
-
-# Library for starting processes
 import multiprocessing
+import threading # needed for the streaming server
+import functools # needed for the streaming server
 
-# Basic planktoscope libraries
+from loguru import logger
+
 import planktoscope.mqtt
-
-# import planktoscope.streamer
 import planktoscope.imager.state_machine
-
-# import raspimjpeg module
 import planktoscope.imager.raspimjpeg
-
-# import streamer module
 import planktoscope.imager.streamer
-
-# Integrity verification module
 import planktoscope.integrity
-
-# Uuid module
-import planktoscope.uuidName
-
-
-# Libraries for the streaming server
-import threading
-import functools
+import planktoscope.identity
 
 
 logger.info("planktoscope.imager is loaded")
@@ -526,12 +498,8 @@ class ImagerProcess(multiprocessing.Process):
             "acq_camera_resolution": f"{self.__resolution[0]}x{self.__resolution[1]}",
             "acq_camera_iso": self.__iso,
             "acq_camera_shutter_speed": self.__shutter_speed,
-            "acq_uuid": planktoscope.uuidName.uuidMachine(
-                machine=planktoscope.uuidName.getSerial()
-            ),
-            "sample_uuid": planktoscope.uuidName.uuidMachine(
-                machine=planktoscope.uuidName.getSerial()
-            ),
+            "acq_uuid": planktoscope.identity.load_machine_name(),
+            "sample_uuid": planktoscope.identity.load_machine_name(),
         }
 
         # Concat the local metadata and the metadata from Node-RED

--- a/processing/segmenter/planktoscope/identity.py
+++ b/processing/segmenter/planktoscope/identity.py
@@ -1,0 +1,11 @@
+# TODO: keep this as the default path, but allow changing it with an environment variable
+MACHINE_NAME_PATH = '/home/pi/.local/etc/machine-name'
+
+def load_machine_name(path=MACHINE_NAME_PATH):
+    """Returns the machine name specified by the file at MACHINE_NAMEPATH.
+
+    Returns:
+        str: the machine name stored in the file at the path.
+    """
+    with open(path, encoding='utf-8') as file:
+        return file.readline().strip()

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -42,6 +42,7 @@ import select
 
 # Basic planktoscope libraries
 import planktoscope.identity
+import planktoscope.uuidName
 import planktoscope.mqtt
 import planktoscope.segmenter.operations
 import planktoscope.segmenter.encoder

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -766,7 +766,8 @@ class SegmenterProcess(multiprocessing.Process):
         logger.info(f"The pipeline will be run in {len(path_list)} directories")
         logger.debug(f"Those are {path_list}")
 
-        self.__process_uuid = planktoscope.uuidName.uuidMachine(
+        self.__process_uuid = planktoscope.identity.load_machine_name()
+        self.__deprecated_process_uuid = planktoscope.uuidName.uuidMachine(
             machine=planktoscope.uuidName.getSerial()
         )
 
@@ -774,6 +775,7 @@ class SegmenterProcess(multiprocessing.Process):
             self.__process_id = self.__process_uuid
 
         logger.info(f"The process_uuid of this run is {self.__process_uuid}")
+        logger.info(f"The deprecated process_uuid is {self.__deprecated_process_uuid}")
         logger.info(f"The process_id of this run is {self.__process_id}")
         exception = None
 

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -41,6 +41,7 @@ import functools
 import select
 
 # Basic planktoscope libraries
+import planktoscope.identity
 import planktoscope.mqtt
 import planktoscope.segmenter.operations
 import planktoscope.segmenter.encoder

--- a/processing/segmenter/planktoscope/uuidName.py
+++ b/processing/segmenter/planktoscope/uuidName.py
@@ -1,0 +1,187 @@
+# Copyright (C) 2021 Romain Bazile
+# 
+# This file is part of the PlanktoScope software.
+# 
+# PlanktoScope is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# PlanktoScope is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with PlanktoScope.  If not, see <http://www.gnu.org/licenses/>.
+
+# Very inspired by https://github.com/bgawalt/uuidBabyName
+import re, uuid, random, os
+
+consonants = "bcdfgjklmnpqrstvwxy"
+vowels = ["a", "e", "i", "o", "u", "ai", "eo", "ou", "io", "au", "ao", "ui", "oa"]
+
+combos = []
+for con in consonants:
+    for vow in vowels:
+        combos.append(con + vow)
+combos += ["puo", "loi", "boi", "roi", "toi", "foi", "poi", "tuo", "ruo"]
+
+
+def popHexPair(s):
+    if len(s) < 3:
+        num = int(s, 16)
+        rest = ""
+    else:
+        num = int(s[0:2], 16)
+        rest = s[2:]
+    return (num, rest)
+
+
+def uuidMachineName(machine="", type=1):
+    """Generates a universally unique name, including the machine name
+
+    When using a type 4 id, the machine name is not taken into account as the uuid is completely random
+
+    Args:
+        machine (str, optional): hex string that defines a machine serial number. Defaults to "".
+        type (int, optional): uuid type to use (1 is node dependant, 4 is completely random). Defaults to 1.
+
+    Returns:
+        str: universally unique name
+    """
+    if type == 4:
+        id = str(uuid.uuid4())
+    elif machine == "":
+        id = str(uuid.uuid1())
+    else:
+        id = str(uuid.uuid1(node=int(str(machine)[-12:], 16)))
+    name = ""
+    x = id.rsplit("-", 1)
+    machine = x[1]
+    x = x[0]
+    x = x.replace("-", "")
+    count = 0
+    while len(x) > 0:
+        tup = popHexPair(x)
+        n = tup[0]
+        if count >= random.randint(2, 4):  # nosec
+            name += " "
+            count = 0
+        name += combos[n]
+        count += 1
+        x = tup[1]
+
+    name += " "
+    count = 0
+
+    while len(machine) > 0:
+        tup = popHexPair(machine)
+        n = tup[0]
+        if count == 3:
+            name += " "
+            count = 0
+        name += combos[n]
+        count += 1
+        machine = tup[1]
+    return name.title()
+
+
+def uuidMachine(machine="", type=1):
+    """Generates a universally unique id, including the machine id
+
+    When using a type 4 id, the machine name is not taken into account as the uuid is completely random
+
+    Args:
+        machine (str, optional): hex string that defines a machine serial number. Defaults to "".
+        type (int, optional): uuid type to use (1 is node dependant, 4 is completely random). Defaults to 1.
+
+    Returns:
+        str: universally unique id
+    """
+    if type == 4:
+        return str(uuid.uuid4())
+    else:
+        return (
+            str(uuid.uuid1())
+            if machine == ""
+            else str(uuid.uuid1(node=int(str(machine)[-12:], 16)))
+        )
+
+
+def uuidName():
+    """Generates a universally unique name, without the machine unique part
+    When used alone, this function can have collisions with other uuname generated on other machines.
+
+    Returns:
+        str: universally unique name, machine dependant
+    """
+    id = str(uuid.uuid1())
+    name = ""
+    x = id.rsplit("-", 1)
+    x = x[0]
+    x = x.replace("-", "")
+    count = 0
+    while len(x) > 0:
+        tup = popHexPair(x)
+        n = tup[0]
+        if count >= random.randint(2, 4):  # nosec
+            name += " "
+            count = 0
+        name += combos[n]
+        count += 1
+        x = tup[1]
+
+    return name.title()
+
+
+def machineName(machine=""):
+    """Generates a machine name based on the same conversion mechanism as other functions in this module
+
+    Args:
+        machine (str, optional): hex string that defines a machine serial number. Defaults to "".
+
+    Returns:
+        str: machine name
+    """
+    if machine == "":
+        machine = str(uuid.getnode())
+    name = ""
+    count = 0
+    machine = machine[-12:]
+    while len(machine) > 0:
+        tup = popHexPair(machine)
+        n = tup[0]
+        if count == 3:
+            name += " "
+            count = 0
+        name += combos[n]
+        count += 1
+        machine = tup[1]
+    return name.title()
+
+
+def getSerial():
+    """Returns a serial number for the machine if run on a Raspberry Pi, otherwise a MAC address
+
+    Returns:
+        str: serial number or MAC address
+    """
+    if not os.path.exists("/sys/firmware/devicetree/base/serial-number"):
+        return str(uuid.getnode())
+
+    with open("/sys/firmware/devicetree/base/serial-number", "r") as serial_file:
+        return serial_file.readline().strip("\x00")
+
+
+if __name__ == "__main__":
+    print("Type 4:")
+    print(uuidMachineName(type=4))
+    print("Type 1:")
+    print(uuidName())
+    print(uuidMachineName())
+    print(machineName())
+    print(uuidMachineName(machine=getSerial()))
+    print(machineName(machine=getSerial()))
+    print(uuidMachineName(machine="10000000e108bd59"))
+    print(machineName(machine="10000000e108bd59"))


### PR DESCRIPTION
This PR is related to https://github.com/PlanktoScope/PlanktoScope/issues/207 and https://github.com/PlanktoScope/PlanktoScope/issues/203. It restores the `uuidName` module (which generates machine names from RPi serial numbers in the old "Baba"-based naming scheme) to the data processing segmenter, since the segmenter logs that name. It also logs the machine names in the new naming scheme; machine names are just loaded from a file on the filesystem (currently hard-coded as `/home/pi/.local/etc/machine-name`; but will be overridable with an environment variable in the future), rather than being computed in Python. This enables a better separation of concerns, since determination of the machine name is more of an OS-level concern; for example, if we run the segmenter in a Docker container in Google Cloud, then we can inject some other machine name into the segmenter.

The `uuidName` module is now deprecated; we will remove it, as well as the logfile lines indicating names in the old naming scheme, from a future release of the software.

TODOs:
- [x] test this PR
- [x] update the changelog