### PR TITLE
Add pixel size calibration to all default configs

### DIFF
--- a/default-configs/adafruithat-latest.hardware.json
+++ b/default-configs/adafruithat-latest.hardware.json
@@ -10,5 +10,6 @@
   "blue_gain": 1.41,
   "analog_gain": 1.0,
   "digital_gain": 1.0,
-  "acq_fnumber_objective": 16
+  "acq_fnumber_objective": 16,
+  "process_pixel_fixed": 0.75
 }

--- a/default-configs/pscopehat-latest.hardware.json
+++ b/default-configs/pscopehat-latest.hardware.json
@@ -1,15 +1,15 @@
 {
-    "stepper_reverse": false,
-    "microsteps": 256,
-    "focus_steps_per_mm": 40,
-    "pump_steps_per_ml": 2045,
-    "focus_max_speed": 5,
-    "pump_max_speed": 50,
-    "stepper_type": "pscope_hat",
-    "red_gain": 2.4,
-    "blue_gain": 1.35,
-    "analog_gain": 1,
-    "digital_gain": 1,
-    "acq_fnumber_objective": 16,
-    "process_pixel_fixed": 0.75
+  "stepper_reverse": false,
+  "microsteps": 256,
+  "focus_steps_per_mm": 40,
+  "pump_steps_per_ml": 2045,
+  "focus_max_speed": 5,
+  "pump_max_speed": 50,
+  "stepper_type": "pscope_hat",
+  "red_gain": 2.4,
+  "blue_gain": 1.35,
+  "analog_gain": 1.0,
+  "digital_gain": 1.0,
+  "acq_fnumber_objective": 16,
+  "process_pixel_fixed": 0.75
 }

--- a/default-configs/v2.1.hardware.json
+++ b/default-configs/v2.1.hardware.json
@@ -10,5 +10,6 @@
   "blue_gain": 1.41,
   "analog_gain": 1.0,
   "digital_gain": 1.0,
-  "acq_fnumber_objective": 16
+  "acq_fnumber_objective": 16,
+  "process_pixel_fixed": 0.75
 }

--- a/default-configs/v2.3.hardware.json
+++ b/default-configs/v2.3.hardware.json
@@ -10,5 +10,6 @@
   "blue_gain": 1.41,
   "analog_gain": 1.0,
   "digital_gain": 1.0,
-  "acq_fnumber_objective": 16
+  "acq_fnumber_objective": 16,
+  "process_pixel_fixed": 0.75
 }

--- a/default-configs/v2.5.hardware.json
+++ b/default-configs/v2.5.hardware.json
@@ -1,15 +1,15 @@
 {
-    "stepper_reverse": false,
-    "microsteps": 256,
-    "focus_steps_per_mm": 40,
-    "pump_steps_per_ml": 2045,
-    "focus_max_speed": 5,
-    "pump_max_speed": 50,
-    "stepper_type": "pscope_hat",
-    "red_gain": 2.4,
-    "blue_gain": 1.35,
-    "analog_gain": 1,
-    "digital_gain": 1,
-    "acq_fnumber_objective": 16,
-    "process_pixel_fixed": 0.75
+  "stepper_reverse": false,
+  "microsteps": 256,
+  "focus_steps_per_mm": 40,
+  "pump_steps_per_ml": 2045,
+  "focus_max_speed": 5,
+  "pump_max_speed": 50,
+  "stepper_type": "pscope_hat",
+  "red_gain": 2.4,
+  "blue_gain": 1.35,
+  "analog_gain": 1.0,
+  "digital_gain": 1.0,
+  "acq_fnumber_objective": 16,
+  "process_pixel_fixed": 0.75
 }


### PR DESCRIPTION
This PR fixes part of https://github.com/PlanktoScope/PlanktoScope/issues/210 by including a pixel size calibration of 0.75 um/pixel as the default value for all default hardware configurations.