### PR TITLE
Bump version numbers for v2023.9.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+## v2023.9.0-beta.1 - 2023-09-14
+
 ### Changed
 
 - The machine name has been switched to the new naming scheme provided by https://github.com/PlanktoScope/machine-name ; the machine name is loaded from a file (currently at `/home/pi/.local/etc/machine-name`, which must be automatically generaed by the host operating system) instead of being determined in Python.
@@ -15,6 +17,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 ### Deprecated
 
 - The old "Baba"-based machine naming scheme should no longer be used. The `uuidName` module will be removed the next stable release (the stable release after v2023.9.0).
+
+### Fixed
+
+- All default settings for all hardware versions now include a default pixel size calibration of 0.75 um/pixel. Previously, the default settings for v2.1 and v2.3 were missing this setting, which would cause the segmenter to crash when processing datasets generated on PlanktoScopes using the v2.1 or v2.3 hardware settings.
 
 ## v2023.9.0-beta.0 - 2023-09-02
 

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -2,7 +2,7 @@
 name = "planktoscope-controller"
 # Note: PEP 440 requires pre-releases to be formatted like "2023.7.0b0" rather than
 # "2023.7.0-beta.0", which is different from the Semantic Versioning schema
-version = "2023.9.0b0"
+version = "2023.9.0b1"
 description = "Controller of PlanktoScope hardware"
 # For simplicity, we follow the definition of "Maintainer" from
 # https://opensource.guide/how-to-contribute/#anatomy-of-an-open-source-project , which says:

--- a/processing/segmenter/pyproject.toml
+++ b/processing/segmenter/pyproject.toml
@@ -2,7 +2,7 @@
 name = "planktoscope-processing-segmenter"
 # Note: PEP 440 requires pre-releases to be formatted like "2023.7.0b0" rather than
 # "2023.7.0-beta.0", which is different from the Semantic Versioning schema
-version = "2023.9.0b0"
+version = "2023.9.0b1"
 description = "Data processor to segment objects from raw PlanktoScope data"
 # For simplicity, we follow the definition of "Maintainer" from
 # https://opensource.guide/how-to-contribute/#anatomy-of-an-open-source-project , which says:


### PR DESCRIPTION
This PR bumps the version to v2023.9.0-beta.1 in preparation for the next beta prerelease of the software distro.