### PR TITLE
Feature/bugfix 259

### DIFF
--- a/control/pscopehat/planktoscope/light.py
+++ b/control/pscopehat/planktoscope/light.py
@@ -45,7 +45,7 @@ class i2c_led:
         id_reset = 0x06
 
     DEVICE_ADDRESS = 0x64
-    # This constant defines the voltage sent to the LED, 10 allows the use of the full ISO scale
+    # This constant defines the current (mA) sent to the LED, 10 allows the use of the full ISO scale and results in a voltage of 2.77v
     DEFAULT_CURRENT = 10
 
     LED_selectPin = 18

--- a/control/pscopehat/planktoscope/light.py
+++ b/control/pscopehat/planktoscope/light.py
@@ -45,7 +45,8 @@ class i2c_led:
         id_reset = 0x06
 
     DEVICE_ADDRESS = 0x64
-    DEFAULT_CURRENT = 20
+    # This constant defines the voltage sent to the LED, 10 allows the use of the full ISO scale
+    DEFAULT_CURRENT = 10
 
     LED_selectPin = 18
 


### PR DESCRIPTION
Here is a pull request concerning the bugfix for the issue #259 on the overexposure issue.
A test was conducted by Thibaut and Laurent on the 2023-11-29 and concluded with the DEFAULT_CURRENT value of 10mA.