### PR TITLE
Change the path of the machine-name file to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.MM.patch` scheme.
+and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
 ## Unreleased
+
+### Changed
+
+- (Breaking change) The machine name is now loaded from `/var/lib/planktoscope/machine-name`, rather than the previous location of `/home/pi/.local/etc/machine-name`.
 
 ## v2023.9.0 - 2023-12-29
 

--- a/control/adafruithat/planktoscope/identity.py
+++ b/control/adafruithat/planktoscope/identity.py
@@ -1,5 +1,5 @@
 # TODO: keep this as the default path, but allow changing it with an environment variable
-MACHINE_NAME_PATH = '/home/pi/.local/etc/machine-name'
+MACHINE_NAME_PATH = '/var/lib/planktoscope/machine-name'
 
 def load_machine_name(path=MACHINE_NAME_PATH):
     """Returns the machine name specified by the file at MACHINE_NAMEPATH.

--- a/control/pscopehat/planktoscope/identity.py
+++ b/control/pscopehat/planktoscope/identity.py
@@ -1,5 +1,5 @@
 # TODO: keep this as the default path, but allow changing it with an environment variable
-MACHINE_NAME_PATH = '/home/pi/.local/etc/machine-name'
+MACHINE_NAME_PATH = '/var/lib/planktoscope/machine-name'
 
 def load_machine_name(path=MACHINE_NAME_PATH):
     """Returns the machine name specified by the file at MACHINE_NAMEPATH.

--- a/processing/segmenter/planktoscope/identity.py
+++ b/processing/segmenter/planktoscope/identity.py
@@ -1,5 +1,5 @@
 # TODO: keep this as the default path, but allow changing it with an environment variable
-MACHINE_NAME_PATH = '/home/pi/.local/etc/machine-name'
+MACHINE_NAME_PATH = '/var/lib/planktoscope/machine-name'
 
 def load_machine_name(path=MACHINE_NAME_PATH):
     """Returns the machine name specified by the file at MACHINE_NAMEPATH.


### PR DESCRIPTION
This PR updates the backend to load the machine name from `/var/lib/planktoscope/machine-name`, due to the changes made in https://github.com/PlanktoScope/PlanktoScope/pull/350 and https://github.com/PlanktoScope/device-pkgs/pull/5 and https://github.com/PlanktoScope/pallet-standard/pull/5.