### PR TITLE
Fix incorrect pixel calibration sizes for v2.5 & v2.6 hardware

### DIFF
--- a/default-configs/v2.5.hardware.json
+++ b/default-configs/v2.5.hardware.json
@@ -11,5 +11,5 @@
   "analog_gain": 1.0,
   "digital_gain": 1.0,
   "acq_fnumber_objective": 16,
-  "process_pixel_fixed": 0.75
+  "process_pixel_fixed": 0.88
 }

--- a/default-configs/v2.6.hardware.json
+++ b/default-configs/v2.6.hardware.json
@@ -11,5 +11,5 @@
   "analog_gain": 1.0,
   "digital_gain": 1.0,
   "acq_fnumber_objective": 12,
-  "process_pixel_fixed": 0.88
+  "process_pixel_fixed": 0.75
 }


### PR DESCRIPTION
This PR fixes errors in the v2.5 and v2.6 hardware config files, where the pixel size calibration values for those two versions had previously been incorrectly swapped.