### PR TITLE
Stop dropping root in segmenter container

### DIFF
--- a/.github/workflows/processing-segmenter-build.yml
+++ b/.github/workflows/processing-segmenter-build.yml
@@ -134,5 +134,6 @@ jobs:
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)     
 
       - name: Inspect image
+        if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'push tag'
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 ### Fixed
 
 - (Hardware controller) The pixel calibration values have been switched between the default v2.5 hardware config file and the default v2.6 hardware config file, so that each file has the correct pixel calibration. The default pscopehat hardware config file has also been updated to include the changes made to the default v2.6 hardware config file.
+- (Breaking change; segmenter) The segmenter now runs as `root` (instead of `pi`) in the Docker container for it, so that it doesn't break on various actual & potential edge cases of files/directories being created with `root` ownership (rather than `pi` ownership) before being bind mounted into the container.
 
 ## v2024.0.0-alpha.0 - 2024-02-06
 

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -2,7 +2,7 @@
 name = "planktoscope-controller"
 # Note: PEP 440 requires pre-releases to be formatted like "2023.7.0b0" rather than
 # "2023.7.0-beta.0", which is different from the Semantic Versioning schema
-version = "2023.9.0"
+version = "2024.0.0a0"
 description = "Controller of PlanktoScope hardware"
 # For simplicity, we follow the definition of "Maintainer" from
 # https://opensource.guide/how-to-contribute/#anatomy-of-an-open-source-project , which says:

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -11,10 +11,9 @@ RUN \
   rm -rf /var/lib/apt/lists/* && \
   rm /tmp/apt-packages
 
-# Drop root user
-
 RUN useradd --create-home pi
-USER pi:pi
+# For now, we don't drop root because dirs are made as root by the hardware controller:
+# USER pi:pi
 RUN mkdir -p /home/pi/device-backend/processing/segmenter
 WORKDIR /home/pi/device-backend/processing/segmenter
 
@@ -38,9 +37,13 @@ RUN \
 
 # Set up application
 
-# Note: we must explicitly set chown here, or else filfes will be copied with root permissions
-COPY --chown=pi:pi main.py .
-COPY --chown=pi:pi planktoscope/ ./planktoscope
+# For now, we don't drop root because dirs are made as root by the hardware controller:
+# Note: we must explicitly set chown if we drop root, or else files will be copied with root
+# permissions.
+# COPY --chown=pi:pi main.py .
+COPY main.py .
+# COPY --chown=pi:pi planktoscope/ ./planktoscope
+COPY planktoscope/ ./planktoscope
 ENTRYPOINT ["/home/pi/.local/bin/poetry", "run", "python", "main.py"]
 EXPOSE 8001
 RUN mkdir -p /home/pi/device-backend-logs/processing/segmenter

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /home/pi/device-backend/processing/segmenter
 # the container image.
 COPY --chown=pi:pi pyproject.toml poetry.lock .
 RUN \
-  export PATH="/root/.local/bin:$PATH" && \
+  export PATH="/home/pi/.local/bin:$PATH" && \
   pip install --no-cache-dir poetry==1.7.1 --extra-index-url https://www.piwheels.org/simple && \
   poetry install --no-root --only main --compile && \
   poetry --no-interaction cache list && \
@@ -41,6 +41,7 @@ RUN \
 # permissions.
 COPY --chown=pi:pi main.py .
 COPY --chown=pi:pi planktoscope/ ./planktoscope
-ENTRYPOINT ["/root/.local/bin/poetry", "run", "python", "main.py"]
+# ENTRYPOINT ["/home/pi/.local/bin/poetry", "run", "python", "main.py"]
+ENTRYPOINT ["/usr/local/bin/poetry", "run", "python", "main.py"]
 EXPOSE 8001
 RUN mkdir -p /home/pi/device-backend-logs/processing/segmenter

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -24,26 +24,23 @@ WORKDIR /home/pi/device-backend/processing/segmenter
 # the container image.
 COPY --chown=pi:pi pyproject.toml poetry.lock .
 RUN \
-  export PATH="/home/pi/.local/bin:$PATH" && \
+  export PATH="/root/.local/bin:$PATH" && \
   pip install --no-cache-dir poetry==1.7.1 --extra-index-url https://www.piwheels.org/simple && \
   poetry install --no-root --only main --compile && \
   poetry --no-interaction cache list && \
   poetry --no-interaction cache clear pypi --all && \
   poetry --no-interaction cache clear piwheels --all && \
-  rm -rf /home/pi/.cache/pypoetry/artifacts && \
-  rm -rf /home/pi/.cache/pypoetry/cache && \
+  rm -rf /root/.cache/pypoetry/artifacts && \
+  rm -rf /root/.cache/pypoetry/cache && \
   pip cache purge && \
-  rm -rf /home/pi/.cache/pip
+  rm -rf /root/.cache/pip
 
 # Set up application
 
-# For now, we don't drop root because dirs are made as root by the hardware controller:
 # Note: we must explicitly set chown if we drop root, or else files will be copied with root
 # permissions.
-# COPY --chown=pi:pi main.py .
-COPY main.py .
-# COPY --chown=pi:pi planktoscope/ ./planktoscope
-COPY planktoscope/ ./planktoscope
-ENTRYPOINT ["/home/pi/.local/bin/poetry", "run", "python", "main.py"]
+COPY --chown=pi:pi main.py .
+COPY --chown=pi:pi planktoscope/ ./planktoscope
+ENTRYPOINT ["/root/.local/bin/poetry", "run", "python", "main.py"]
 EXPOSE 8001
 RUN mkdir -p /home/pi/device-backend-logs/processing/segmenter

--- a/processing/segmenter/pyproject.toml
+++ b/processing/segmenter/pyproject.toml
@@ -2,7 +2,7 @@
 name = "planktoscope-processing-segmenter"
 # Note: PEP 440 requires pre-releases to be formatted like "2023.7.0b0" rather than
 # "2023.7.0-beta.0", which is different from the Semantic Versioning schema
-version = "2023.9.0"
+version = "2024.0.0a0"
 description = "Data processor to segment objects from raw PlanktoScope data"
 # For simplicity, we follow the definition of "Maintainer" from
 # https://opensource.guide/how-to-contribute/#anatomy-of-an-open-source-project , which says:


### PR DESCRIPTION
This PR reverts a change introduced in #17, which had dropped the user from `root` to `pi` for [security reasons](https://pythonspeed.com/articles/root-capabilities-docker-security/). However, that caused problems because bind mounts of nonexistent directories on the host are created by the Docker daemon (which we're running with root privileges) with root ownership, so that the segmenter container itself is unable to access such directories; and because subdirectories of `/home/pi/data/img` are created on the host by the Python hardware controller with root ownership, so that the segmenter container is unable to create `done.txt` files under those subdirectories (as reported by @tpollina in https://planktoscope.slack.com/archives/C015K99AJAE/p1708530438903539).

A longer-term solution would be to switch from Docker to Podman (so that we can run all these containers as a non-`root` user) and/or to make the Python hardware controller run without root. For now, this PR just reverts the segmenter to run as root so that it won't break in unexpected ways on files/directories created with `root` ownership.