### PR TITLE
Bump dependencies

### DIFF
--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -106,13 +106,13 @@ pidng = [
   { version = "~4.0.9", source = "pypi", markers = "platform_machine != 'armv7l'" },
 ]
 simplejpeg = [
-  { version = "==1.6.4", source = "pypi", markers = "platform_machine != 'armv7l'" },
+  { version = "~1.6.4", source = "pypi", markers = "platform_machine != 'armv7l'" },
 ]
 pillow = [
-  { version = "==8.1.2", source = "pypi", markers = "platform_machine != 'armv7l'" },
+  { version = "~10.2.0", source = "pypi", markers = "platform_machine != 'armv7l'" },
 ]
 av = [
-  { version = "10.0.0", source = "pypi", markers = "platform_machine != 'armv7l'" },
+  { version = "~10.0.0", source = "pypi", markers = "platform_machine != 'armv7l'" },
 ]
 
 [tool.poetry.group.dev]

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.18-slim-bullseye
+FROM docker.io/library/python:3.9.18-slim-bullseye
 
 # Install OS dependencies
 


### PR DESCRIPTION
This PR resolves a bunch of dependabot security alerts introduced as a result of #19, by bumping the version of Pillow used for GitHub Actions CI checks (note that on the Raspberry Pi we're still using the old version of Pillow provided by the host OS, because for some reason poetry is unable to download the pre-built wheels and instead must re-build things from source for transitive dependencies of picamera2).