### PR TITLE
Only subtract consecutive masks when an env var is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Changed
+
+- (Breaking change; segmenter) Previously, the segmenter's default behavior was to subtract consecutive masks to try to mitigate image-processing issues with objects which get stuck to the flowcell during imaging. However, when different objects occupied the same space in consecutive frames, the subtraction behavior would subtract one object's mask from the mask of the other object in the following frame, which would produce clearly incorrect masks. This behavior is no longer enabled by default; in order to re-enable it, you should set the environment variable `SEGMENTER_PIPELINE_SUBTRACT_CONSECUTIVE_MASKS=true` when launching the segmenter.
+
 ## v2024.0.0-alpha.1 - 2024-03-26
 
 ### Added

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -71,7 +71,9 @@ SUBTRACT_CONSECUTIVE_MASKS = os.getenv(
     "False"
 ).lower() in ('true', '1', 't')
 if SUBTRACT_CONSECUTIVE_MASKS:
-    logger.info("planktoscope.segmenter will subtract masks between consecutive raw frames!")
+    logger.info("The segmentation pipeline {will} subtract masks between consecutive raw frames!")
+else:
+    logger.info("The segmentation pipeline {will} NOT subtract masks between consecutive raw frames!")
 
 
 ################################################################################

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -70,6 +70,8 @@ SUBTRACT_CONSECUTIVE_MASKS = os.getenv(
     "SEGMENTER_PIPELINE_SUBTRACT_CONSECUTIVE_MASKS",
     "False"
 ).lower() in ('true', '1', 't')
+if SUBTRACT_CONSECUTIVE_MASKS:
+    logger.info("planktoscope.segmenter will subtract masks between consecutive raw frames!")
 
 
 ################################################################################

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -35,6 +35,7 @@ import json, shutil, os
 import multiprocessing
 
 import io
+import os
 
 import threading
 import functools
@@ -61,6 +62,14 @@ import math
 
 
 logger.info("planktoscope.segmenter is loaded")
+
+
+# Note(ethanjli): if/when we start having more env vars, we may want to start using the `environs`
+# package from PyPI for more structured parsing of env vars:
+SUBTRACT_CONSECUTIVE_MASKS = os.getenv(
+    "SEGMENTER_PIPELINE_SUBTRACT_CONSECUTIVE_MASKS",
+    "False"
+).lower() in ('true', '1', 't')
 
 
 ################################################################################
@@ -237,7 +246,7 @@ class SegmenterProcess(multiprocessing.Process):
         pipeline = [
             # "adaptative_threshold",
             "simple_threshold",
-            "remove_previous_mask",
+            "remove_previous_mask" if SUBTRACT_CONSECUTIVE_MASKS else "no_op",
             "erode",
             "dilate",
             "close",
@@ -834,7 +843,7 @@ class SegmenterProcess(multiprocessing.Process):
             "parameters": {"algorithm": "THRESH_TRIANGLE"},
         }
         self.__global_metadata["process_3rd_operation"] = {
-            "type": "remove_previous_mask",
+            "type": "remove_previous_mask" if SUBTRACT_CONSECUTIVE_MASKS else "no_op",
             "parameters": {},
         }
         self.__global_metadata["process_4th_operation"] = {

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -71,9 +71,9 @@ SUBTRACT_CONSECUTIVE_MASKS = os.getenv(
     "False"
 ).lower() in ('true', '1', 't')
 if SUBTRACT_CONSECUTIVE_MASKS:
-    logger.info("The segmentation pipeline {will} subtract masks between consecutive raw frames!")
+    logger.info("The segmentation pipeline will subtract masks between consecutive raw frames!")
 else:
-    logger.info("The segmentation pipeline {will} NOT subtract masks between consecutive raw frames!")
+    logger.info("The segmentation pipeline will NOT subtract masks between consecutive raw frames!")
 
 
 ################################################################################

--- a/processing/segmenter/planktoscope/segmenter/operations.py
+++ b/processing/segmenter/planktoscope/segmenter/operations.py
@@ -197,6 +197,15 @@ def remove_previous_mask(mask):
         return __mask_to_remove
 
 
+def no_op(mask):
+    """Return the mask without modifying it.
+
+    This is provided as a quick-and-dirty hack to disable certain steps in the pipeline such as
+    remove_previous_mask, by allowing those steps to be substituted with this no-op step.
+    """
+    return mask
+
+
 def reset_previous_mask():
     """Remove the mask from the previous pass from the given mask
     The given mask is then saved to be applied to the next pass


### PR DESCRIPTION
This PR implements a requirement which @tpollina added to the v2024.0.0 milestone as a **breaking change** to make for the v2024.0.0-beta.0 prerelease (refer to the [2024-04-11 software meeting](https://docs.google.com/document/d/1Iba0_9yNFEDdp1Qy8IYlLP43Ga0DnDr3CdavWV0QGZY/edit#heading=h.e3f0mm3ng2sj) for context) to the behavior of the segmenter, so that by default it will no longer subtract consecutive masks from each other in the frame-processing pipeline.

Following a suggestion by @W7CH , I have made it possible for users to re-enable the behavior which this PR changes to be disabled by default - specifically, the segmenter now checks to see if the environment variable `SEGMENTER_PIPELINE_SUBTRACT_CONSECUTIVE_MASKS` is set to `true`, and if so, then the segmenter will perform subtraction between consecutive masks. If the environment variable is not set, the segmenter will follow the new default behavior (no subtraction). This environment variable will be controllable by the Forklift package `core/apps/planktoscope/device-backend/processing/segmenter` as a feature flag (in https://github.com/PlanktoScope/device-pkgs/pull/10).