### PR TITLE
Fix various picamera2 camera settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - (Breaking change; segmenter) Previously, the segmenter's default behavior was to subtract consecutive masks to try to mitigate image-processing issues with objects which get stuck to the flowcell during imaging. However, when different objects occupied the same space in consecutive frames, the subtraction behavior would subtract one object's mask from the mask of the other object in the following frame, which would produce clearly incorrect masks. This behavior is no longer enabled by default; in order to re-enable it, you should set the environment variable `SEGMENTER_PIPELINE_SUBTRACT_CONSECUTIVE_MASKS=true` when launching the segmenter.
 - (Hardware controller) The image quality of frames in the camera preview stream for the picamera2-based imager is increased, and frames also have greater width and height.
 
+### Deprecated
+
+- (Hardware controller) The old raspimjpeg-based imager is deprecated and will be fully deleted in a subsequent release (potentially as early as v2024.1.0).
+
 ### Fixed
 
 - (Hardware controller) The incorrect scaling factor for converting between ISO settings (in the MQTT API) and image gains is fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 ### Changed
 
 - (Breaking change; segmenter) Previously, the segmenter's default behavior was to subtract consecutive masks to try to mitigate image-processing issues with objects which get stuck to the flowcell during imaging. However, when different objects occupied the same space in consecutive frames, the subtraction behavior would subtract one object's mask from the mask of the other object in the following frame, which would produce clearly incorrect masks. This behavior is no longer enabled by default; in order to re-enable it, you should set the environment variable `SEGMENTER_PIPELINE_SUBTRACT_CONSECUTIVE_MASKS=true` when launching the segmenter.
+- (Hardware controller) The image quality of frames in the camera preview stream for the picamera2-based imager is increased, and frames also have greater width and height.
+
+### Fixed
+
+- (Hardware controller) The incorrect scaling factor for converting between ISO settings (in the MQTT API) and image gains is fixed.
 
 ## v2024.0.0-alpha.1 - 2024-03-26
 

--- a/control/README.md
+++ b/control/README.md
@@ -36,6 +36,14 @@ And you can run all checks (including code formatting and linting) by running:
 poetry run poe check
 ```
 
+If you'd like to copy your files to a remote PlanktoScope, you can run:
+```
+HOST=pkscope.local poetry run scp
+```
+from the directory which contains this readme. Note that this command requires that you have a
+`scp` command (so you probably need to be running on Linux or macOS, or on Windows Subsystem for
+Linux). And you can change `pkscope.local` to something else (e.g. `home.pkscope`) if needed.
+
 ### Prerequisites
 
 To use this project, you'll need:

--- a/control/README.md
+++ b/control/README.md
@@ -38,11 +38,14 @@ poetry run poe check
 
 If you'd like to copy your files to a remote PlanktoScope, you can run:
 ```
-HOST=pkscope.local poetry run scp
+HOST=pkscope.local poetry run poe scp
 ```
-from the directory which contains this readme. Note that this command requires that you have a
-`scp` command (so you probably need to be running on Linux or macOS, or on Windows Subsystem for
-Linux). And you can change `pkscope.local` to something else (e.g. `home.pkscope`) if needed.
+from the directory which contains this readme. This command will overwrite existing files in
+`/home/pi/device-backend/control`, but it will not delete any files or directories which you might
+have deleted from your computer's local copy of this directory. Note that this command requires that
+you have a `scp` command (so you probably need to be running on Linux or macOS, or on Windows
+Subsystem for Linux). And you can change `pkscope.local` to something else (e.g. `home.pkscope`) if
+needed.
 
 ### Prerequisites
 

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -290,9 +290,10 @@ class PiCamera:
             # `MJPEGEncoder` instead:
             encoders.MJPEGEncoder(bitrate=self._stream_config.preview_bitrate),
             outputs.FileOutput(self._preview_output),
-            # If we specify quality, it overrides the bitrate (contrary to what the picamera2 docs
-            # say (refer to https://github.com/raspberrypi/picamera2/blob/a89eb1dc39578fb764d792d83ba34095a9597f80/picamera2/encoders/mjpeg_encoder.py#L23):
-            #quality=encoders.Quality.VERY_HIGH,
+            # If we specify quality, it overrides the bitrate, contrary to what the picamera2 docs
+            # say (refer to
+            # github.com/raspberrypi/picamera2/blob/main/picamera2/encoders/mjpeg_encoder.py#L23):
+            # quality=encoders.Quality.VERY_HIGH,
             name="lores",
         )
 

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -219,7 +219,7 @@ class PiCamera:
     def __init__(
         self,
         preview_output: io.BufferedIOBase,
-        stream_config: StreamConfig = StreamConfig(preview_size=(640, 480), buffer_count=3),
+        stream_config: StreamConfig = StreamConfig(preview_size=(960, 720), buffer_count=3),
         initial_settings: SettingsValues = SettingsValues(),
     ) -> None:
         """Set up state needed to initialize the camera, but don't actually start the camera yet.

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -219,7 +219,13 @@ class PiCamera:
     def __init__(
         self,
         preview_output: io.BufferedIOBase,
-        stream_config: StreamConfig = StreamConfig(preview_size=(960, 720), buffer_count=3),
+        stream_config: StreamConfig = StreamConfig(
+            preview_size=(960, 720),
+            # We'll never reach 80 Mbps of bandwidth usage because the RPi's network links don't
+            # have enough bandwidth; instead, we'll have higher-quality frames at lower framerates:
+            preview_bitrate=80 * 1000000,
+            buffer_count=3,
+        ),
         initial_settings: SettingsValues = SettingsValues(),
     ) -> None:
         """Set up state needed to initialize the camera, but don't actually start the camera yet.
@@ -284,7 +290,9 @@ class PiCamera:
             # `MJPEGEncoder` instead:
             encoders.MJPEGEncoder(bitrate=self._stream_config.preview_bitrate),
             outputs.FileOutput(self._preview_output),
-            quality=encoders.Quality.HIGH,
+            # If we specify quality, it overrides the bitrate (contrary to what the picamera2 docs
+            # say (refer to https://github.com/raspberrypi/picamera2/blob/a89eb1dc39578fb764d792d83ba34095a9597f80/picamera2/encoders/mjpeg_encoder.py#L23):
+            #quality=encoders.Quality.VERY_HIGH,
             name="lores",
         )
 

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -290,9 +290,10 @@ class PiCamera:
             # `MJPEGEncoder` instead:
             encoders.MJPEGEncoder(bitrate=self._stream_config.preview_bitrate),
             outputs.FileOutput(self._preview_output),
-            # If we specify quality, it overrides the bitrate (contrary to what the picamera2 docs
-            # say (refer to https://github.com/raspberrypi/picamera2/blob/a89eb1dc39578fb764d792d83ba34095a9597f80/picamera2/encoders/mjpeg_encoder.py#L23):
-            #quality=encoders.Quality.VERY_HIGH,
+            # If we specify quality, it overrides the bitrate, contrary to what the picamera2 docs
+            # say (refer to
+            # github.com/raspberrypi/picamera2/blob/main/picamera2/encoders/mjpeg_encoder.py#L23):
+            # quality=encoders.Quality.VERY_HIGH,
             name="lores",
         )
 

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -219,7 +219,7 @@ class PiCamera:
     def __init__(
         self,
         preview_output: io.BufferedIOBase,
-        stream_config: StreamConfig = StreamConfig(preview_size=(640, 480), buffer_count=3),
+        stream_config: StreamConfig = StreamConfig(preview_size=(960, 720), buffer_count=3),
         initial_settings: SettingsValues = SettingsValues(),
     ) -> None:
         """Set up state needed to initialize the camera, but don't actually start the camera yet.

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -219,7 +219,13 @@ class PiCamera:
     def __init__(
         self,
         preview_output: io.BufferedIOBase,
-        stream_config: StreamConfig = StreamConfig(preview_size=(960, 720), buffer_count=3),
+        stream_config: StreamConfig = StreamConfig(
+            preview_size=(960, 720),
+            # We'll never reach 80 Mbps of bandwidth usage because the RPi's network links don't
+            # have enough bandwidth; instead, we'll have higher-quality frames at lower framerates:
+            preview_bitrate=80 * 1000000,
+            buffer_count=3,
+        ),
         initial_settings: SettingsValues = SettingsValues(),
     ) -> None:
         """Set up state needed to initialize the camera, but don't actually start the camera yet.
@@ -284,7 +290,9 @@ class PiCamera:
             # `MJPEGEncoder` instead:
             encoders.MJPEGEncoder(bitrate=self._stream_config.preview_bitrate),
             outputs.FileOutput(self._preview_output),
-            quality=encoders.Quality.HIGH,
+            # If we specify quality, it overrides the bitrate (contrary to what the picamera2 docs
+            # say (refer to https://github.com/raspberrypi/picamera2/blob/a89eb1dc39578fb764d792d83ba34095a9597f80/picamera2/encoders/mjpeg_encoder.py#L23):
+            #quality=encoders.Quality.VERY_HIGH,
             name="lores",
         )
 

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -353,3 +353,4 @@ lint-pylint-planktoscopehat = "pylint planktoscopehat"
 lint-pylint = ["lint-pylint-adafruithat", "lint-pylint-planktoscopehat"]
 lint = ["lint-mypy", "lint-pylama", "lint-flake8", "lint-pylint"]
 check = ["check-black", "check-isort", "lint"]
+scp = "scp -r . pi@${HOST}:/home/pi/device-backend/control"


### PR DESCRIPTION
This PR fixes various issues identified in the [2024-04-11 software meeting](https://docs.google.com/document/d/1Iba0_9yNFEDdp1Qy8IYlLP43Ga0DnDr3CdavWV0QGZY/edit#heading=h.e3f0mm3ng2sj) as blockers for the v2024.0.0-beta.0 software prerelease, namely:

- The conversion factors between ISO and image gain were using incorrect scaling factors.
- The image quality of the camera preview stream was not adequate for image focusing.

This PR also includes a basic (minimum viable) implementation of a poethepoet command (using SCP) to help make it easy to upload the local copy of hardware controller Python files to a PlanktoScope over ssh, following an idea raised during a discussion with @Oumayma-hy in the [2024-04-18 software meeting](https://docs.google.com/document/d/1Iba0_9yNFEDdp1Qy8IYlLP43Ga0DnDr3CdavWV0QGZY/edit#heading=h.9mqgnhl0tgfq). See the changes to `control/README.md` for details.