### PR TITLE
Pull back default planktoscopehat hardware config to v2.5 hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Added
+
+- (Hardware controller) A default fairscope-latest hardware config file has been created as the default v2.6 hardware config file.
+
+### Changed
+
+- (Breaking change; hardware controller) The default planktoscopehat hardware config file has been rolled back from the default v2.6 hardware config file to the default v2.5 hardware config file. This reverts a change made in v2024.0.0-alpha.1.
+
 ## v2024.0.0-beta.0 - 2024-06-07
 
 (this release involves no changes from v2024.0.0-alpha.2; it's just a promotion of v204.0.0-alpha.2 to a beta pre-release)

--- a/default-configs/fairscope-latest.hardware.json
+++ b/default-configs/fairscope-latest.hardware.json
@@ -10,6 +10,6 @@
   "blue_gain": 1.35,
   "analog_gain": 1.0,
   "digital_gain": 1.0,
-  "acq_fnumber_objective": 16,
-  "process_pixel_fixed": 0.88
+  "acq_fnumber_objective": 12,
+  "process_pixel_fixed": 0.75
 }


### PR DESCRIPTION
This PR (along with https://github.com/PlanktoScope/PlanktoScope/pull/430) is part of a prototype for a discussion in the [2024-06-13 software meeting](https://docs.google.com/document/d/1yqRMceF52-kezI2drtvw3Zbv9zkgCo27n7X2q2vmAeI/edit#heading=h.8qcosaymfqo0) about pulling back the default hardware version for the `planktoscopehat` build of the PlanktoScope OS from v2.6 back to v2.5 (reverting a change made in #12 and 118ea1e13212826319fa3b818987124fe2d4dfae) and instead using v2.6 as the default hardware version for a FairScope-specific build of the Planktoscope OS.