### PR TITLE
Initialize camera image gain to a consistent ISO of 150

### DIFF
--- a/.github/workflows/release-channel-beta.yml
+++ b/.github/workflows/release-channel-beta.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-beta.*'
-      # We want to advance the beta to the latest stable release, too:
+      # We want to advance the beta branch to the latest stable release, too:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Changed
+
+- (Hardware controller) The default image gain used to initialize the camera module is now set to match a default equivalent ISO value of 150 across all camera sensor types, instead of being hard-coded to 1.0 (which corresponds to an ISO of around 40 or 50 depending on the camera sensor type).
+
 ## v2024.0.0-beta.1 - 2024-06-24
 
 ### Added

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -314,7 +314,7 @@ class PiCamera:
         """Update adjustable camera settings from all provided non-`None` values.
 
         Fields provided with `None` values are ignored. If any of the provided non-`None` values is
-        invalid (e.g. out-of-range), none of the settinsg will be changed.
+        invalid (e.g. out-of-range), none of the settings will be changed.
 
         Raises:
             RuntimeError: the method was called before the camera was started, or after it was

--- a/control/adafruithat/planktoscope/camera/mqtt.py
+++ b/control/adafruithat/planktoscope/camera/mqtt.py
@@ -33,7 +33,7 @@ class Worker(threading.Thread):
         settings = hardware.SettingsValues(
             auto_exposure=False,
             exposure_time=125,  # the default (minimum) exposure time in the PlanktoScope GUI
-            image_gain=1.0,  # the default ISO of 100 in the PlanktoScope GUI
+            image_gain=1.0,  # image gain is reinitialized after the image sensor is determined
             brightness=0.0,  # the default "normal" brightness
             contrast=1.0,  # the default "normal" contrast
             auto_white_balance=False,  # the default setting in the PlanktoScope GUI
@@ -82,6 +82,24 @@ class Worker(threading.Thread):
             self._camera_checked.set()
             return
         self._camera_checked.set()
+
+        default_iso = 150
+        loguru.logger.debug(f"Setting camera image gain for default ISO value of {default_iso}...")
+        # 100 is the default calibration because that's what's used in the Pi Camera v1 Module, and
+        # it's a round number:
+        calibration = ISO_CALIBRATIONS.get(self._camera.sensor_name, 100)
+        changes = hardware.SettingsValues(image_gain=default_iso / calibration)
+        try:
+            _validate_settings(changes)
+        except (TypeError, ValueError) as e:
+            loguru.logger.exception(
+                f"Couldn't default ISO value to valid settings: {settings}",
+            )
+            return json.dumps({"status": f"Error: {str(e)}"})
+        self._camera.settings = changes
+        loguru.logger.debug(
+            f"Set image gain to {changes.image_gain} for sensor {self._camera.sensor_name}!",
+        )
 
         loguru.logger.info("Starting the MJPEG streaming server...")
         streaming_server = mjpeg.StreamingServer(self._preview_stream, self._mjpeg_server_address)
@@ -220,6 +238,16 @@ def _convert_settings(
     return converted
 
 
+# Refer to https://picamera.readthedocs.io/en/release-1.13/fov.html#sensor-gain for
+# details on how ISO values correspond to image gains with the Pi Camera v2 Module,
+# and refer to https://forums.raspberrypi.com/viewtopic.php?t=282760 for details on ISO
+# vs. image gain calibration for the Pi HQ Camera Module:
+ISO_CALIBRATIONS = {  # this is ISO / image-gain
+    "IMX219": 100 / 1.84,    # Pi Camera v2 Module
+    "IMX477": 100 / 2.3125,  # Pi HQ Camera Module
+}
+
+
 def _convert_image_gain_settings(
     command_settings: dict[str, typing.Any],
     camera_sensor_name: str,
@@ -253,17 +281,9 @@ def _convert_image_gain_settings(
             iso = float(command_settings["iso"])
         except (TypeError, ValueError) as e:
             raise ValueError("Iso number not valid") from e
-        # Refer to https://picamera.readthedocs.io/en/release-1.13/fov.html#sensor-gain for
-        # details on how ISO values correspond to image gains with the Pi Camera v2 Module,
-        # and refer to https://forums.raspberrypi.com/viewtopic.php?t=282760 for details on ISO
-        # vs. image gain calibration for the Pi HQ Camera Module:
-        iso_calibrations = {  # this is ISO / image-gain
-            "IMX219": 100 / 1.84,  # Pi Camera v2 Module
-            "IMX477": 100 / 2.3125,  # Pi HQ Camera Module
-        }
         # 100 is the default calibration because that's what's used in the Pi Camera v1 Module, and
         # it's a round number:
-        calibration = iso_calibrations.get(camera_sensor_name, 100)
+        calibration = ISO_CALIBRATIONS.get(camera_sensor_name, 100)
         converted = converted._replace(image_gain=iso / calibration)
 
     return converted

--- a/control/adafruithat/planktoscope/camera/mqtt.py
+++ b/control/adafruithat/planktoscope/camera/mqtt.py
@@ -93,9 +93,8 @@ class Worker(threading.Thread):
             _validate_settings(changes)
         except (TypeError, ValueError) as e:
             loguru.logger.exception(
-                f"Couldn't default ISO value to valid settings: {settings}",
+                f"Couldn't default ISO value to valid settings: {changes}",
             )
-            return json.dumps({"status": f"Error: {str(e)}"})
         self._camera.settings = changes
         loguru.logger.debug(
             f"Set image gain to {changes.image_gain} for sensor {self._camera.sensor_name}!",

--- a/control/adafruithat/planktoscope/camera/mqtt.py
+++ b/control/adafruithat/planktoscope/camera/mqtt.py
@@ -92,9 +92,7 @@ class Worker(threading.Thread):
         try:
             _validate_settings(changes)
         except (TypeError, ValueError) as e:
-            loguru.logger.exception(
-                f"Couldn't default ISO value to valid settings: {changes}",
-            )
+            raise ValueError("Invalid default ISO") from e
         self._camera.settings = changes
         loguru.logger.debug(
             f"Set image gain to {changes.image_gain} for sensor {self._camera.sensor_name}!",
@@ -242,7 +240,7 @@ def _convert_settings(
 # and refer to https://forums.raspberrypi.com/viewtopic.php?t=282760 for details on ISO
 # vs. image gain calibration for the Pi HQ Camera Module:
 ISO_CALIBRATIONS = {  # this is ISO / image-gain
-    "IMX219": 100 / 1.84,    # Pi Camera v2 Module
+    "IMX219": 100 / 1.84,  # Pi Camera v2 Module
     "IMX477": 100 / 2.3125,  # Pi HQ Camera Module
 }
 

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -314,7 +314,7 @@ class PiCamera:
         """Update adjustable camera settings from all provided non-`None` values.
 
         Fields provided with `None` values are ignored. If any of the provided non-`None` values is
-        invalid (e.g. out-of-range), none of the settinsg will be changed.
+        invalid (e.g. out-of-range), none of the settings will be changed.
 
         Raises:
             RuntimeError: the method was called before the camera was started, or after it was

--- a/control/planktoscopehat/planktoscope/camera/mqtt.py
+++ b/control/planktoscopehat/planktoscope/camera/mqtt.py
@@ -92,9 +92,7 @@ class Worker(threading.Thread):
         try:
             _validate_settings(changes)
         except (TypeError, ValueError) as e:
-            loguru.logger.exception(
-                f"Couldn't default ISO value to valid settings: {changes}",
-            )
+            raise ValueError("Invalid default ISO") from e
         self._camera.settings = changes
         loguru.logger.debug(
             f"Set image gain to {changes.image_gain} for sensor {self._camera.sensor_name}!",

--- a/control/planktoscopehat/planktoscope/camera/mqtt.py
+++ b/control/planktoscopehat/planktoscope/camera/mqtt.py
@@ -242,7 +242,7 @@ def _convert_settings(
 # and refer to https://forums.raspberrypi.com/viewtopic.php?t=282760 for details on ISO
 # vs. image gain calibration for the Pi HQ Camera Module:
 ISO_CALIBRATIONS = {  # this is ISO / image-gain
-    "IMX219": 100 / 1.84,    # Pi Camera v2 Module
+    "IMX219": 100 / 1.84,  # Pi Camera v2 Module
     "IMX477": 100 / 2.3125,  # Pi HQ Camera Module
 }
 

--- a/control/planktoscopehat/planktoscope/camera/mqtt.py
+++ b/control/planktoscopehat/planktoscope/camera/mqtt.py
@@ -33,7 +33,7 @@ class Worker(threading.Thread):
         settings = hardware.SettingsValues(
             auto_exposure=False,
             exposure_time=125,  # the default (minimum) exposure time in the PlanktoScope GUI
-            image_gain=1.0,  # the default ISO of 100 in the PlanktoScope GUI
+            image_gain=1.0,  # image gain is reinitialized after the image sensor is determined
             brightness=0.0,  # the default "normal" brightness
             contrast=1.0,  # the default "normal" contrast
             auto_white_balance=False,  # the default setting in the PlanktoScope GUI
@@ -82,6 +82,24 @@ class Worker(threading.Thread):
             self._camera_checked.set()
             return
         self._camera_checked.set()
+
+        default_iso = 150
+        loguru.logger.debug(f"Setting camera image gain for default ISO value of {default_iso}...")
+        # 100 is the default calibration because that's what's used in the Pi Camera v1 Module, and
+        # it's a round number:
+        calibration = ISO_CALIBRATIONS.get(self._camera.sensor_name, 100)
+        changes = hardware.SettingsValues(image_gain=default_iso / calibration)
+        try:
+            _validate_settings(changes)
+        except (TypeError, ValueError) as e:
+            loguru.logger.exception(
+                f"Couldn't default ISO value to valid settings: {settings}",
+            )
+            return json.dumps({"status": f"Error: {str(e)}"})
+        self._camera.settings = changes
+        loguru.logger.debug(
+            f"Set image gain to {changes.image_gain} for sensor {self._camera.sensor_name}!",
+        )
 
         loguru.logger.info("Starting the MJPEG streaming server...")
         streaming_server = mjpeg.StreamingServer(self._preview_stream, self._mjpeg_server_address)
@@ -220,6 +238,16 @@ def _convert_settings(
     return converted
 
 
+# Refer to https://picamera.readthedocs.io/en/release-1.13/fov.html#sensor-gain for
+# details on how ISO values correspond to image gains with the Pi Camera v2 Module,
+# and refer to https://forums.raspberrypi.com/viewtopic.php?t=282760 for details on ISO
+# vs. image gain calibration for the Pi HQ Camera Module:
+ISO_CALIBRATIONS = {  # this is ISO / image-gain
+    "IMX219": 100 / 1.84,    # Pi Camera v2 Module
+    "IMX477": 100 / 2.3125,  # Pi HQ Camera Module
+}
+
+
 def _convert_image_gain_settings(
     command_settings: dict[str, typing.Any],
     camera_sensor_name: str,
@@ -253,17 +281,9 @@ def _convert_image_gain_settings(
             iso = float(command_settings["iso"])
         except (TypeError, ValueError) as e:
             raise ValueError("Iso number not valid") from e
-        # Refer to https://picamera.readthedocs.io/en/release-1.13/fov.html#sensor-gain for
-        # details on how ISO values correspond to image gains with the Pi Camera v2 Module,
-        # and refer to https://forums.raspberrypi.com/viewtopic.php?t=282760 for details on ISO
-        # vs. image gain calibration for the Pi HQ Camera Module:
-        iso_calibrations = {  # this is ISO / image-gain
-            "IMX219": 100 / 1.84,  # Pi Camera v2 Module
-            "IMX477": 100 / 2.3125,  # Pi HQ Camera Module
-        }
         # 100 is the default calibration because that's what's used in the Pi Camera v1 Module, and
         # it's a round number:
-        calibration = iso_calibrations.get(camera_sensor_name, 100)
+        calibration = ISO_CALIBRATIONS.get(camera_sensor_name, 100)
         converted = converted._replace(image_gain=iso / calibration)
 
     return converted

--- a/control/planktoscopehat/planktoscope/camera/mqtt.py
+++ b/control/planktoscopehat/planktoscope/camera/mqtt.py
@@ -93,9 +93,8 @@ class Worker(threading.Thread):
             _validate_settings(changes)
         except (TypeError, ValueError) as e:
             loguru.logger.exception(
-                f"Couldn't default ISO value to valid settings: {settings}",
+                f"Couldn't default ISO value to valid settings: {changes}",
             )
-            return json.dumps({"status": f"Error: {str(e)}"})
         self._camera.settings = changes
         loguru.logger.debug(
             f"Set image gain to {changes.image_gain} for sensor {self._camera.sensor_name}!",


### PR DESCRIPTION
This PR is part of a fix for a regression reported to me (privately, in DMs) by @fabienlombard on PlanktoScope OS v2024.0.0-beta.1, in which the default ISO setting displayed on the Node-RED dashboard was inconsistent with the actual initial image gain (of 1.0, which corresponds to an ISO of ~54 on the PlanktoScope hardware v2.1's camera and an ISO of ~43 on the PlanktoScope hardware v2.3+'s camera). This PR initializes the image gain value to match a consistent ISO setting of 150, which will become the default ISO setting for both the adafruithat Node-RED dashboard and the planktoscopehat Node-RED dashboard.

This fix was discussed and approved in the [2024-07-25 software meeting](https://docs.google.com/document/d/1yqRMceF52-kezI2drtvw3Zbv9zkgCo27n7X2q2vmAeI/edit#heading=h.6csyvp7b4rjc).