### PR TITLE
Draw fitted ellipse in diagnostic images

### DIFF
--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -551,6 +551,15 @@ class SegmenterProcess(multiprocessing.Process):
                         color=(150, 0, 200),
                         thickness=1,
                     )
+                    tagged_image = cv2.ellipse(
+                        tagged_image,
+                        center=region.centroid,
+                        axes=(region.axis_major_length, region.axis_minor_length),
+                        angle=math.degrees(region.orientation),
+                        startAngle=0,
+                        endAngle=360,
+                        color=(150, 0, 200),
+                    )
                     contours, hierarchy = cv2.findContours(
                         np.uint8(region.image),
                         mode=cv2.RETR_TREE,  # RETR_FLOODFILL or RETR_EXTERNAL


### PR DESCRIPTION
This PR adds functionality to draw the region's fitted ellipse in the `tagged.jpg` diagnostic images saved by the segmenter; those ellipses are useful for understanding biases in the ellipsoid biovolume estimates described at https://www.protocols.io/view/planktoscope-protocol-for-plankton-imaging-bp2l6bq3zgqe/v3?step=16 , and for comparing ellipsoid biovolume against plain/riddled biovolume estimates.