### PR TITLE
Fix incorrect segmenter object size thresholding calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 - (Hardware controller) The bitrate of the camera preview stream has been reduced slightly from ~8 Mbps to ~7 Mbps.
 - (Hardware controller) The framerate of the camera preview stream is now explicitly limited to 25 fps.
 
+### Fixed
+
+- (Breaking change; segmenter) The previously incorrect method for filtering segmented objects by size has now been corrected to filter object sizes by filled area rather than bounding box area, and directly using the mesh size as the threshold for equivalent spherical diameter (ESD) instead of calculating a fictional ESD.
+
 ## v2024.0.0-beta.2 - 2024-08-19
 
 ### Changed

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -25,7 +25,8 @@ WORKDIR /home/pi/device-backend/processing/segmenter
 COPY --chown=pi:pi pyproject.toml poetry.lock .
 RUN \
   export PATH="/home/pi/.local/bin:$PATH" && \
-  pip install --no-cache-dir poetry==1.7.1 --extra-index-url https://www.piwheels.org/simple && \
+  pip install --no-cache-dir cryptography==42.0.8 poetry==1.7.1 \
+    --extra-index-url https://www.piwheels.org/simple && \
   poetry install --no-root --only main --compile && \
   poetry --no-interaction cache list && \
   poetry --no-interaction cache clear pypi --all && \

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /home/pi/device-backend/processing/segmenter
 COPY --chown=pi:pi pyproject.toml poetry.lock .
 RUN \
   export PATH="/home/pi/.local/bin:$PATH" && \
-  pip install --no-cache-dir cryptography==42.0.8 poetry==1.7.1 \
+  pip install --no-cache-dir cryptography==43.0.3 poetry==1.7.1 \
     --extra-index-url https://www.piwheels.org/simple && \
   poetry install --no-root --only main --compile && \
   poetry --no-interaction cache list && \

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -474,17 +474,16 @@ class SegmenterProcess(multiprocessing.Process):
             dim_slice = tuple(dim_slice)
             return dim_slice
 
-        minMesh = self.__global_metadata.get("acq_minimum_mesh", 20)  # microns
-        minESD = minMesh * 2
-        minArea = math.pi * (minESD / 2) * (minESD / 2)
-        pixel_size = self.__global_metadata.get("process_pixel", 1.0)
-        # minsizepix = minArea / pixel_size / pixel_size
-        minsizepix = (minESD / pixel_size) ** 2
+        min_mesh = self.__global_metadata.get("acq_minimum_mesh", 20)  # microns
+        min_esd = min_mesh # or process_min_ESD in the future (microns)
+        pixel_size = self.__global_metadata["process_pixel"]
+        min_radius = min_esd / 2 / pixel_size # (pixels)
+        min_area = math.pi * min_radius * min_radius
 
         labels, nlabels = skimage.measure.label(mask, return_num=True)
         regionprops = skimage.measure.regionprops(labels)
         regionprops_filtered = [
-            region for region in regionprops if region.bbox_area >= minsizepix
+            region for region in regionprops if prop.filled_area >= min_area
         ]
         object_number = len(regionprops_filtered)
         logger.debug(f"Found {nlabels} labels, or {object_number} after size filtering")

--- a/processing/segmenter/planktoscope/segmenter/__init__.py
+++ b/processing/segmenter/planktoscope/segmenter/__init__.py
@@ -483,7 +483,7 @@ class SegmenterProcess(multiprocessing.Process):
         labels, nlabels = skimage.measure.label(mask, return_num=True)
         regionprops = skimage.measure.regionprops(labels)
         regionprops_filtered = [
-            region for region in regionprops if prop.filled_area >= min_area
+            region for region in regionprops if region.filled_area >= min_area
         ]
         object_number = len(regionprops_filtered)
         logger.debug(f"Found {nlabels} labels, or {object_number} after size filtering")


### PR DESCRIPTION
This PR is part of a fix for https://github.com/PlanktoScope/PlanktoScope/issues/114 ; this PR makes the fix which was proposed at https://github.com/PlanktoScope/PlanktoScope/issues/89#issuecomment-2405625882 , discussed in the [2024-10-17 software meeting](https://docs.google.com/document/d/1Sq0rqxOLi0h2hlvAo50e_UXm2fOa1FaKFnn4CNLB8TI/edit?tab=t.0#heading=h.e1cyde8yk5va), and approved (by Thibaut) in the [2024-10-24 software meeting](https://docs.google.com/document/d/1Sq0rqxOLi0h2hlvAo50e_UXm2fOa1FaKFnn4CNLB8TI/edit?tab=t.0#heading=h.porgcudwb01c) for inclusion in v2024.0.0 of PlanktoScope OS.

TODO:
- [x] Update `CHANGELOG.md`
- [x] Update PlanktoScope reference docs (https://github.com/PlanktoScope/PlanktoScope/pull/496)