### PR TITLE
Try to mitigate camera preview stream latency problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Changed
+
+- (Hardware controller) The resolution of the camera preview stream has been reduced from 960x720 to 800x600 in an attempt to mitigate hard-to-reproduce preview stream latency problems.
 - (Hardware controller) The bitrate of the camera preview stream has been reduced slightly from ~8 Mbps to ~7 Mbps.
-- (Hardware controller) The framerate of the camera preview stream is now explicitly limited to 15 fps.
+- (Hardware controller) The framerate of the camera preview stream is now explicitly limited to 25 fps.
 
 ## v2024.0.0-beta.2 - 2024-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+- (Hardware controller) The bitrate of the camera preview stream has been reduced slightly from ~8 Mbps to ~7 Mbps.
+- (Hardware controller) The framerate of the camera preview stream is now explicitly limited to 15 fps.
+
 ## v2024.0.0-beta.2 - 2024-08-19
 
 ### Changed

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -221,11 +221,15 @@ class PiCamera:
         preview_output: io.BufferedIOBase,
         stream_config: StreamConfig = StreamConfig(
             preview_size=(960, 720),
-            # We'll never reach 80 Mbps of bandwidth usage because the RPi's network links don't
-            # have enough bandwidth; instead, we'll have higher-quality frames at lower framerates:
-            preview_bitrate=80 * 1000000,
+            # Note(ethanjli): a bitrate of 80 Mbps in practice results in ~8 Mbps of bandwidth per
+            # stream, both for Ethernet and for the Wi-Fi hotspot. A bitrate of 20 Mbps results in
+            # ~7 Mbps of bandwidth per stream. A bitrate of 15 Mbps results in noticeable JPEG
+            # compression artifacts, and ~5 Mbps of bandwidth per stream.
+            preview_bitrate=20 * 1000000,
             buffer_count=3,
         ),
+        # Note(ethanjli): mqtt.Worker's constructor explicitly overrides any defaults we set here -
+        # to set default initial settings, modify mqtt.Worker's constructor instead!
         initial_settings: SettingsValues = SettingsValues(),
     ) -> None:
         """Set up state needed to initialize the camera, but don't actually start the camera yet.
@@ -433,10 +437,10 @@ class PreviewStream(io.BufferedIOBase):
     """A thread-safe stream of discrete byte buffers for use in live previews.
 
     This stream is designed to support at-most-once delivery, so no guarantees are made about
-    delivery of every buffer to the consumers: a consumer will skip buffers when it's too busy
-    overloaded/blocked. This is a design feature to prevent backpressure on certain consumers
-    (e.g. from downstream clients sending the buffer across a network, when the buffer is a large
-    image) from degrading stream quality for everyone.
+    delivery of every buffer to the consumers: a consumer is allowed to skip buffers when it's too
+    busy. This is a design feature to prevent backpressure on certain consumers (e.g. from
+    downstream clients sending the buffer across a network, when the buffer is a large image) from
+    degrading stream quality for everyone.
 
     Note that no thread synchronization is managed for any buffer; consumers must avoid modifying
     the buffer once they have access to it.

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -220,12 +220,12 @@ class PiCamera:
         self,
         preview_output: io.BufferedIOBase,
         stream_config: StreamConfig = StreamConfig(
-            preview_size=(960, 720),
+            preview_size=(800, 600),
             # Note(ethanjli): a bitrate of 80 Mbps in practice results in ~8 Mbps of bandwidth per
             # stream, both for Ethernet and for the Wi-Fi hotspot. A bitrate of 20 Mbps results in
             # ~7 Mbps of bandwidth per stream. A bitrate of 15 Mbps results in noticeable JPEG
             # compression artifacts, and ~5 Mbps of bandwidth per stream.
-            preview_bitrate=20 * 1000000,
+            preview_bitrate=25 * 1000000,
             buffer_count=3,
         ),
         # Note(ethanjli): mqtt.Worker's constructor explicitly overrides any defaults we set here -

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -442,9 +442,6 @@ class PreviewStream(io.BufferedIOBase):
     downstream clients sending the buffer across a network, when the buffer is a large image) from
     degrading stream quality for everyone.
 
-    Note that no thread synchronization is managed for any buffer; consumers must avoid modifying
-    the buffer once they have access to it.
-
     This stream can be used by anything which requires a [io.BufferedIOBase], assuming it never
     splits any buffer across multiple calls of the `write()` method.
     """
@@ -483,6 +480,7 @@ class PreviewStream(io.BufferedIOBase):
             self._available.wait()
 
     def get(self) -> typing.Optional[bytes]:
-        """Return the latest buffer in the stream."""
+        """Return a copy of the latest buffer in the stream."""
         with self._latest_buffer_lock.gen_rlock():
-            return self._latest_buffer
+            b = self._latest_buffer[:]
+        return b

--- a/control/adafruithat/planktoscope/camera/hardware.py
+++ b/control/adafruithat/planktoscope/camera/hardware.py
@@ -481,6 +481,8 @@ class PreviewStream(io.BufferedIOBase):
 
     def get(self) -> typing.Optional[bytes]:
         """Return a copy of the latest buffer in the stream."""
+        if self._latest_buffer is None:
+            return None
         with self._latest_buffer_lock.gen_rlock():
             b = self._latest_buffer[:]
         return b

--- a/control/adafruithat/planktoscope/camera/mjpeg.py
+++ b/control/adafruithat/planktoscope/camera/mjpeg.py
@@ -3,6 +3,7 @@
 import functools
 import socket
 import socketserver
+import time
 import typing
 from http import server
 
@@ -27,8 +28,10 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         request: typing.Union[socket.socket, tuple[bytes, socket.socket]],
         client_address: tuple[str, int],
         server_: socketserver.BaseServer,
+        max_framerate: typing.Optional[int] = 15,  # fps
     ) -> None:
         self.latest_frame = latest_frame
+        self._max_framerate = max_framerate
         super().__init__(request, client_address, server_)
 
     @loguru.logger.catch
@@ -50,19 +53,37 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
             # TODO(ethanjli): allow specifying a max framerate via HTTP GET query param? Currently
             # we have no way to reduce bandwidth usage below the maximum supported by the network
             # connection to the client.
-            self._send_mjpeg_header()
+            # Note(ethanjli): there's definitely a better way to ensure unique client IDs, but
+            # unix timestamp is the simplest idea I had at the time:
+            client_id = time.time()
+            loguru.logger.info(f"Added streaming client {client_id}.")
             try:
-                while True:
-                    self.latest_frame.wait_next()
-                    if (frame := self.latest_frame.get()) is None:
-                        continue
-                    self._send_mjpeg_frame(frame)
+                self._send_frames(client_id)
             except BrokenPipeError:
-                loguru.logger.info("Removed streaming client")
+                loguru.logger.info(f"Removed streaming client {client_id}.")
             return
 
         self.send_error(404)
         self.end_headers()
+
+    def _send_frames(self, client_id: float) -> None:
+        """Send frames as they become available."""
+        min_interval = 0.0
+        if self._max_framerate is not None:
+            min_interval = 1.0 / self._max_framerate  # s
+        # TODO: measure histograms of frame wait duration and frame send duration. Log any
+        # anomalies (i.e. unexpectedly high durations)
+        self._send_mjpeg_header()
+        last_frame_time = time.perf_counter()
+        while True:
+            waited = False
+            while not waited or time.perf_counter() - last_frame_time < min_interval:
+                self.latest_frame.wait_next()
+                waited = True
+            if (frame := self.latest_frame.get()) is None:
+                continue
+            last_frame_time = time.perf_counter()
+            self._send_mjpeg_frame(frame)
 
     def _send_mjpeg_header(self) -> None:
         """Send the headers to start an MJPEG stream."""

--- a/control/adafruithat/planktoscope/camera/mjpeg.py
+++ b/control/adafruithat/planktoscope/camera/mjpeg.py
@@ -28,10 +28,9 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         request: typing.Union[socket.socket, tuple[bytes, socket.socket]],
         client_address: tuple[str, int],
         server_: socketserver.BaseServer,
-        max_framerate: typing.Optional[int] = 15,  # fps
     ) -> None:
         self.latest_frame = latest_frame
-        self._max_framerate = max_framerate
+        self._max_framerate = 15  # fps
         super().__init__(request, client_address, server_)
 
     @loguru.logger.catch
@@ -58,7 +57,7 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
             client_id = time.time()
             loguru.logger.info(f"Added streaming client {client_id}.")
             try:
-                self._send_frames(client_id)
+                self._send_frames()
             except BrokenPipeError:
                 loguru.logger.info(f"Removed streaming client {client_id}.")
             return
@@ -66,7 +65,7 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         self.send_error(404)
         self.end_headers()
 
-    def _send_frames(self, client_id: float) -> None:
+    def _send_frames(self) -> None:
         """Send frames as they become available."""
         min_interval = 0.0
         if self._max_framerate is not None:

--- a/control/adafruithat/planktoscope/camera/mjpeg.py
+++ b/control/adafruithat/planktoscope/camera/mjpeg.py
@@ -30,7 +30,7 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         server_: socketserver.BaseServer,
     ) -> None:
         self.latest_frame = latest_frame
-        self._max_framerate = 15  # fps
+        self._max_framerate = 25  # fps
         super().__init__(request, client_address, server_)
 
     @loguru.logger.catch

--- a/control/adafruithat/planktoscope/camera/mjpeg.py
+++ b/control/adafruithat/planktoscope/camera/mjpeg.py
@@ -71,6 +71,9 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         min_interval = 0.0
         if self._max_framerate is not None:
             min_interval = 1.0 / self._max_framerate  # s
+        # TODO: manually make a histogram as a collection of counters with durations corresponding
+        # to >30 fps, 30 fps, 25 fps, 20 fps, 15 fps, 10 fps, 5 fps, 2 fps, 1 fps, <1 fps. Clear
+        # the histogram after each scheduled report.
         # TODO: measure histograms of frame wait duration and frame send duration. Log any
         # anomalies (i.e. unexpectedly high durations)
         self._send_mjpeg_header()

--- a/control/adafruithat/planktoscope/camera/mqtt.py
+++ b/control/adafruithat/planktoscope/camera/mqtt.py
@@ -33,6 +33,11 @@ class Worker(threading.Thread):
         settings = hardware.SettingsValues(
             auto_exposure=False,
             exposure_time=125,  # the default (minimum) exposure time in the PlanktoScope GUI
+            # Note(ethanjli): an error will occur if exposure time is outside any provided frame
+            # duration limits (set by explicitly defining a `frame_duration_limits` param here. In
+            # practice, this means we cannot reduce the max allowed framerate below
+            # 1/(125 us) = 8000 fps, for exposure time of 125 us. So we have to limit the framerate
+            # some other way.
             image_gain=1.0,  # image gain is reinitialized after the image sensor is determined
             brightness=0.0,  # the default "normal" brightness
             contrast=1.0,  # the default "normal" contrast

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -221,11 +221,15 @@ class PiCamera:
         preview_output: io.BufferedIOBase,
         stream_config: StreamConfig = StreamConfig(
             preview_size=(960, 720),
-            # We'll never reach 80 Mbps of bandwidth usage because the RPi's network links don't
-            # have enough bandwidth; instead, we'll have higher-quality frames at lower framerates:
-            preview_bitrate=80 * 1000000,
+            # Note(ethanjli): a bitrate of 80 Mbps in practice results in ~8 Mbps of bandwidth per
+            # stream, both for Ethernet and for the Wi-Fi hotspot. A bitrate of 20 Mbps results in
+            # ~7 Mbps of bandwidth per stream. A bitrate of 15 Mbps results in noticeable JPEG
+            # compression artifacts, and ~5 Mbps of bandwidth per stream.
+            preview_bitrate=20 * 1000000,
             buffer_count=3,
         ),
+        # Note(ethanjli): mqtt.Worker's constructor explicitly overrides any defaults we set here -
+        # to set default initial settings, modify mqtt.Worker's constructor instead!
         initial_settings: SettingsValues = SettingsValues(),
     ) -> None:
         """Set up state needed to initialize the camera, but don't actually start the camera yet.
@@ -433,10 +437,10 @@ class PreviewStream(io.BufferedIOBase):
     """A thread-safe stream of discrete byte buffers for use in live previews.
 
     This stream is designed to support at-most-once delivery, so no guarantees are made about
-    delivery of every buffer to the consumers: a consumer will skip buffers when it's too busy
-    overloaded/blocked. This is a design feature to prevent backpressure on certain consumers
-    (e.g. from downstream clients sending the buffer across a network, when the buffer is a large
-    image) from degrading stream quality for everyone.
+    delivery of every buffer to the consumers: a consumer is allowed to skip buffers when it's too
+    busy. This is a design feature to prevent backpressure on certain consumers (e.g. from
+    downstream clients sending the buffer across a network, when the buffer is a large image) from
+    degrading stream quality for everyone.
 
     Note that no thread synchronization is managed for any buffer; consumers must avoid modifying
     the buffer once they have access to it.

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -220,12 +220,12 @@ class PiCamera:
         self,
         preview_output: io.BufferedIOBase,
         stream_config: StreamConfig = StreamConfig(
-            preview_size=(960, 720),
+            preview_size=(800, 600),
             # Note(ethanjli): a bitrate of 80 Mbps in practice results in ~8 Mbps of bandwidth per
             # stream, both for Ethernet and for the Wi-Fi hotspot. A bitrate of 20 Mbps results in
             # ~7 Mbps of bandwidth per stream. A bitrate of 15 Mbps results in noticeable JPEG
             # compression artifacts, and ~5 Mbps of bandwidth per stream.
-            preview_bitrate=20 * 1000000,
+            preview_bitrate=25 * 1000000,
             buffer_count=3,
         ),
         # Note(ethanjli): mqtt.Worker's constructor explicitly overrides any defaults we set here -

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -442,9 +442,6 @@ class PreviewStream(io.BufferedIOBase):
     downstream clients sending the buffer across a network, when the buffer is a large image) from
     degrading stream quality for everyone.
 
-    Note that no thread synchronization is managed for any buffer; consumers must avoid modifying
-    the buffer once they have access to it.
-
     This stream can be used by anything which requires a [io.BufferedIOBase], assuming it never
     splits any buffer across multiple calls of the `write()` method.
     """
@@ -483,6 +480,7 @@ class PreviewStream(io.BufferedIOBase):
             self._available.wait()
 
     def get(self) -> typing.Optional[bytes]:
-        """Return the latest buffer in the stream."""
+        """Return a copy of the latest buffer in the stream."""
         with self._latest_buffer_lock.gen_rlock():
-            return self._latest_buffer
+            b = self._latest_buffer[:]
+        return b

--- a/control/planktoscopehat/planktoscope/camera/hardware.py
+++ b/control/planktoscopehat/planktoscope/camera/hardware.py
@@ -481,6 +481,8 @@ class PreviewStream(io.BufferedIOBase):
 
     def get(self) -> typing.Optional[bytes]:
         """Return a copy of the latest buffer in the stream."""
+        if self._latest_buffer is None:
+            return None
         with self._latest_buffer_lock.gen_rlock():
             b = self._latest_buffer[:]
         return b

--- a/control/planktoscopehat/planktoscope/camera/mjpeg.py
+++ b/control/planktoscopehat/planktoscope/camera/mjpeg.py
@@ -3,6 +3,7 @@
 import functools
 import socket
 import socketserver
+import time
 import typing
 from http import server
 
@@ -27,8 +28,10 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         request: typing.Union[socket.socket, tuple[bytes, socket.socket]],
         client_address: tuple[str, int],
         server_: socketserver.BaseServer,
+        max_framerate: typing.Optional[int] = 25,  # fps
     ) -> None:
         self.latest_frame = latest_frame
+        self._max_framerate = max_framerate
         super().__init__(request, client_address, server_)
 
     @loguru.logger.catch
@@ -50,19 +53,37 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
             # TODO(ethanjli): allow specifying a max framerate via HTTP GET query param? Currently
             # we have no way to reduce bandwidth usage below the maximum supported by the network
             # connection to the client.
-            self._send_mjpeg_header()
+            # Note(ethanjli): there's definitely a better way to ensure unique client IDs, but
+            # unix timestamp is the simplest idea I had at the time:
+            client_id = time.time()
+            loguru.logger.info(f"Added streaming client {client_id}.")
             try:
-                while True:
-                    self.latest_frame.wait_next()
-                    if (frame := self.latest_frame.get()) is None:
-                        continue
-                    self._send_mjpeg_frame(frame)
+                self._send_frames(client_id)
             except BrokenPipeError:
-                loguru.logger.info("Removed streaming client")
+                loguru.logger.info(f"Removed streaming client {client_id}.")
             return
 
         self.send_error(404)
         self.end_headers()
+
+    def _send_frames(self, client_id: float) -> None:
+        """Send frames as they become available."""
+        min_interval = 0.0
+        if self._max_framerate is not None:
+            min_interval = 1.0 / self._max_framerate  # s
+        # TODO: measure histograms of frame wait duration and frame send duration. Log any
+        # anomalies (i.e. unexpectedly high durations)
+        self._send_mjpeg_header()
+        last_frame_time = time.time()
+        while True:
+            waited = False
+            while not waited or time.time() - last_frame_time < min_interval:
+                self.latest_frame.wait_next()
+                waited = True
+            if (frame := self.latest_frame.get()) is None:
+                continue
+            last_frame_time = time.time()
+            self._send_mjpeg_frame(frame)
 
     def _send_mjpeg_header(self) -> None:
         """Send the headers to start an MJPEG stream."""

--- a/control/planktoscopehat/planktoscope/camera/mjpeg.py
+++ b/control/planktoscopehat/planktoscope/camera/mjpeg.py
@@ -28,10 +28,9 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         request: typing.Union[socket.socket, tuple[bytes, socket.socket]],
         client_address: tuple[str, int],
         server_: socketserver.BaseServer,
-        max_framerate: typing.Optional[int] = 15,  # fps
     ) -> None:
         self.latest_frame = latest_frame
-        self._max_framerate = max_framerate
+        self._max_framerate = 15  # fps
         super().__init__(request, client_address, server_)
 
     @loguru.logger.catch
@@ -58,7 +57,7 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
             client_id = time.time()
             loguru.logger.info(f"Added streaming client {client_id}.")
             try:
-                self._send_frames(client_id)
+                self._send_frames()
             except BrokenPipeError:
                 loguru.logger.info(f"Removed streaming client {client_id}.")
             return
@@ -66,7 +65,7 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         self.send_error(404)
         self.end_headers()
 
-    def _send_frames(self, client_id: float) -> None:
+    def _send_frames(self) -> None:
         """Send frames as they become available."""
         min_interval = 0.0
         if self._max_framerate is not None:

--- a/control/planktoscopehat/planktoscope/camera/mjpeg.py
+++ b/control/planktoscopehat/planktoscope/camera/mjpeg.py
@@ -28,7 +28,7 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         request: typing.Union[socket.socket, tuple[bytes, socket.socket]],
         client_address: tuple[str, int],
         server_: socketserver.BaseServer,
-        max_framerate: typing.Optional[int] = 25,  # fps
+        max_framerate: typing.Optional[int] = 15,  # fps
     ) -> None:
         self.latest_frame = latest_frame
         self._max_framerate = max_framerate

--- a/control/planktoscopehat/planktoscope/camera/mjpeg.py
+++ b/control/planktoscopehat/planktoscope/camera/mjpeg.py
@@ -74,15 +74,15 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         # TODO: measure histograms of frame wait duration and frame send duration. Log any
         # anomalies (i.e. unexpectedly high durations)
         self._send_mjpeg_header()
-        last_frame_time = time.time()
+        last_frame_time = time.perf_counter()
         while True:
             waited = False
-            while not waited or time.time() - last_frame_time < min_interval:
+            while not waited or time.perf_counter() - last_frame_time < min_interval:
                 self.latest_frame.wait_next()
                 waited = True
             if (frame := self.latest_frame.get()) is None:
                 continue
-            last_frame_time = time.time()
+            last_frame_time = time.perf_counter()
             self._send_mjpeg_frame(frame)
 
     def _send_mjpeg_header(self) -> None:

--- a/control/planktoscopehat/planktoscope/camera/mjpeg.py
+++ b/control/planktoscopehat/planktoscope/camera/mjpeg.py
@@ -30,7 +30,7 @@ class _StreamingHandler(server.BaseHTTPRequestHandler):
         server_: socketserver.BaseServer,
     ) -> None:
         self.latest_frame = latest_frame
-        self._max_framerate = 15  # fps
+        self._max_framerate = 25  # fps
         super().__init__(request, client_address, server_)
 
     @loguru.logger.catch

--- a/control/planktoscopehat/planktoscope/camera/mqtt.py
+++ b/control/planktoscopehat/planktoscope/camera/mqtt.py
@@ -33,6 +33,11 @@ class Worker(threading.Thread):
         settings = hardware.SettingsValues(
             auto_exposure=False,
             exposure_time=125,  # the default (minimum) exposure time in the PlanktoScope GUI
+            # Note(ethanjli): an error will occur if exposure time is outside any provided frame
+            # duration limits (set by explicitly defining a `frame_duration_limits` param here. In
+            # practice, this means we cannot reduce the max allowed framerate below
+            # 1/(125 us) = 8000 fps, for exposure time of 125 us. So we have to limit the framerate
+            # some other way.
             image_gain=1.0,  # image gain is reinitialized after the image sensor is determined
             brightness=0.0,  # the default "normal" brightness
             contrast=1.0,  # the default "normal" contrast

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -25,7 +25,6 @@ WORKDIR /home/pi/device-backend/processing/segmenter
 COPY --chown=pi:pi pyproject.toml poetry.lock .
 RUN \
   export PATH="/home/pi/.local/bin:$PATH" && \
-  pip install --no-cache-dir poetry==1.7.1 --extra-index-url https://www.piwheels.org/simple && \
   pip install --no-cache-dir cryptography==43.0.3 poetry==1.7.1 \
     --extra-index-url https://www.piwheels.org/simple && \
   poetry install --no-root --only main --compile && \

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -26,7 +26,7 @@ COPY --chown=pi:pi pyproject.toml poetry.lock .
 RUN \
   export PATH="/home/pi/.local/bin:$PATH" && \
   pip install --no-cache-dir poetry==1.7.1 --extra-index-url https://www.piwheels.org/simple && \
-  pip install --no-cache-dir cryptography==42.0.8 poetry==1.7.1 \
+  pip install --no-cache-dir cryptography==43.0.3 poetry==1.7.1 \
     --extra-index-url https://www.piwheels.org/simple && \
   poetry install --no-root --only main --compile && \
   poetry --no-interaction cache list && \

--- a/processing/segmenter/Dockerfile
+++ b/processing/segmenter/Dockerfile
@@ -26,6 +26,8 @@ COPY --chown=pi:pi pyproject.toml poetry.lock .
 RUN \
   export PATH="/home/pi/.local/bin:$PATH" && \
   pip install --no-cache-dir poetry==1.7.1 --extra-index-url https://www.piwheels.org/simple && \
+  pip install --no-cache-dir cryptography==42.0.8 poetry==1.7.1 \
+    --extra-index-url https://www.piwheels.org/simple && \
   poetry install --no-root --only main --compile && \
   poetry --no-interaction cache list && \
   poetry --no-interaction cache clear pypi --all && \


### PR DESCRIPTION
This PR implements the workaround proposed at https://planktoscope.slack.com/archives/C01V5ENKG0M/p1732209129043269 to reduce the occurrence/severity of camera preview latency events discussed/troubleshooted at https://planktoscope.slack.com/archives/C01V5ENKG0M/p1724939562549999 and the [2024-10 - 2024-11 software meetings](https://docs.google.com/document/d/1Sq0rqxOLi0h2hlvAo50e_UXm2fOa1FaKFnn4CNLB8TI/edit?tab=t.0). Specifically, this PR adjusts camera preview stream parameters and adds a stream framerate limiter.

TODOs:
- [x] Adjust stream parameters according to the final proposal
- [x] Update `CHANGELOG.md`