### PR TITLE
Use merge gatekeeper to avoid running slow CI workflows when not needed

### DIFF
--- a/.github/workflows/control-build.yml
+++ b/.github/workflows/control-build.yml
@@ -24,7 +24,7 @@ env:
   IMAGE_NAME: device-backend-control
 
 jobs:
-  ci:
+  ci-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/control-build.yml
+++ b/.github/workflows/control-build.yml
@@ -9,6 +9,9 @@ on:
     tags:
       - 'v*'
   pull_request:
+    paths:
+      - 'control/**'
+      - '.github/workflows/control-*.yml'
   merge_group:
   workflow_dispatch:
     inputs:
@@ -23,8 +26,6 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,0 +1,18 @@
+---
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 600 # 10-minute timeout, since ARM v7 container builds may take ~5 minutes to run

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           timeout: 600 # 10-minute timeout, since ARM v7 container builds may take ~5 minutes to run
+          interval: 30

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -27,4 +27,4 @@ jobs:
           ref: ${{github.ref}}
           token: ${{ secrets.GITHUB_TOKEN }}
           timeout: 600 # 10-minute timeout, since ARM v7 container builds may take ~5 minutes to run
-          interval: 30
+          interval: 15

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -3,6 +3,7 @@ name: Merge Gatekeeper
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   merge-gatekeeper:
@@ -12,8 +13,18 @@ jobs:
       statuses: read
     steps:
       - name: Run Merge Gatekeeper
+        if: github.event_name != 'merge_group'
         uses: upsidr/merge-gatekeeper@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 600 # 10-minute timeout, since ARM v7 container builds may take ~5 minutes to run
+          interval: 30
+
+      - name: Run Merge Gatekeeper in Merge Queue
+        if: github.event_name == 'merge_group'
+        uses: upsidr/merge-gatekeeper@v1
+        with:
+          ref: ${{github.ref}}
           token: ${{ secrets.GITHUB_TOKEN }}
           timeout: 600 # 10-minute timeout, since ARM v7 container builds may take ~5 minutes to run
           interval: 30

--- a/.github/workflows/processing-segmenter-build.yml
+++ b/.github/workflows/processing-segmenter-build.yml
@@ -109,7 +109,7 @@ jobs:
   merge-container-images:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - build-container-image
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/processing-segmenter-build.yml
+++ b/.github/workflows/processing-segmenter-build.yml
@@ -9,6 +9,9 @@ on:
     tags:
       - 'v*'
   pull_request:
+    paths:
+      - 'processing/segmenter/**'
+      - '.github/workflows/processing-segmenter-*.yml'
   merge_group:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/processing-segmenter-build.yml
+++ b/.github/workflows/processing-segmenter-build.yml
@@ -29,7 +29,7 @@ env:
   PUSH_IMAGE: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'push' || github.event_name == 'push tag' }}
 
 jobs:
-  build:
+  build-container-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -106,7 +106,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
+  merge-container-images:
     runs-on: ubuntu-latest
     needs:
       - build

--- a/processing/segmenter/README.md
+++ b/processing/segmenter/README.md
@@ -12,7 +12,7 @@ This repository contains the PlanktoScope's segmenter, which detects objects fro
 
 The segmenter is published for deployment as a Docker container image at [https://ghcr.io/PlanktoScope/device-backend-processing-segmenter](https://github.com/PlanktoScope/device-backend/pkgs/container/device-backend-processing-segmenter). Note that the segmenter requires an MQTT broker accessible on the port 1883 of the host, as well as something to send MQTT commands to the segmenter.
 
-Currently, the simplest way to deploy the segmenter on any computer is using the [Forklift](https://github.com/PlanktoScope/forklift) pallet [github.com/PlanktoScope/pallet-segmenter](https://github.com/PlanktoScope/pallet-segmenter).
+Currently, the simplest way to deploy the segmenter on any computer is using the [Forklift](https://github.com/PlanktoScope/forklift) pallet [github.com/PlanktoScope/pallet-segmenter](https://github.com/PlanktoScope/pallet-segmenter). However, that method is still experimental.
 
 ### Development
 


### PR DESCRIPTION
This PR attempts to avoid needing to run CI checks for the hardware controller on PRs which only modify the segmenter (and vice versa), by adding https://github.com/upsidr/merge-gatekeeper and making that the only required check.