### PR TITLE
Fix incorrect use of `img_rank` field in EcoTaxa export metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## Unreleased
+
+### Fixed
+
+- (Segmenter) The segmenter now correctly sets the `img_rank` metadata field of the EcoTaxa export to `1`, instead of setting it to an incrementing index which makes exports un-importable by EcoTaxa for datasets with more than ~32,000 objects.
+
 ## v2024.0.0-beta.3 - 2024-11-30
 
 ### Changed

--- a/processing/segmenter/planktoscope/segmenter/ecotaxa.py
+++ b/processing/segmenter/planktoscope/segmenter/ecotaxa.py
@@ -1,17 +1,17 @@
 # Copyright (C) 2021 Romain Bazile
-# 
+#
 # This file is part of the PlanktoScope software.
-# 
+#
 # PlanktoScope is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # PlanktoScope is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with PlanktoScope.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -238,10 +238,10 @@ def ecotaxa_export(archive_filepath, metadata, image_base_path, keep_files=False
             return 0
 
         # sometimes the camera resolution is not exported as string
-        if type(metadata["acq_camera_resolution"]) != str:
-            metadata[
-                "acq_camera_resolution"
-            ] = f'{metadata["acq_camera_resolution"][0]}x{metadata["acq_camera_resolution"][1]}'
+        if not isinstance(metadata["acq_camera_resolution"], str):
+            metadata["acq_camera_resolution"] = (
+                f'{metadata["acq_camera_resolution"][0]}x{metadata["acq_camera_resolution"][1]}'
+            )
 
         # let's go!
         for rank, roi in enumerate(object_list, start=1):
@@ -252,7 +252,7 @@ def ecotaxa_export(archive_filepath, metadata, image_base_path, keep_files=False
 
             filename = roi["name"] + ".jpg"
 
-            tsv_line.update({"img_file_name": filename, "img_rank": rank})
+            tsv_line.update({"img_file_name": filename, "img_rank": 1})
             tsv_content.append(tsv_line)
 
             image_path = os.path.join(image_base_path, filename)
@@ -264,16 +264,14 @@ def ecotaxa_export(archive_filepath, metadata, image_base_path, keep_files=False
 
         tsv_content = pandas.DataFrame(tsv_content)
 
-        tsv_type_header = [
-            dtype_to_ecotaxa(dt) for dt in tsv_content.dtypes
-        ]
+        tsv_type_header = [dtype_to_ecotaxa(dt) for dt in tsv_content.dtypes]
         tsv_content.columns = pandas.MultiIndex.from_tuples(
             list(zip(tsv_content.columns, tsv_type_header))
         )
 
         # create the filename with the acquisition ID
         acquisition_id = metadata.get("acq_id")
-        acquisition_id = acquisition_id.replace(" ","_")
+        acquisition_id = acquisition_id.replace(" ", "_")
         tsv_filename = f"ecotaxa_{acquisition_id}.tsv"
 
         # add the tsv to the archive


### PR DESCRIPTION
This PR fixes a problem reported by @fabienlombard [on the PlanktoScope Slack workspace](https://planktoscope.slack.com/archives/C01V5ENKG0M/p1733327391060119), in which the segmenter's behavior to set the `img_rank` metadata field to the index of the image in the entire dataset was incorrect; that rank is instead supposed to be used to set a display priority among alternate images (e.g. brightfield vs fluorescence) corresponding to the same object. And EcoTaxa cannot handle `img_rank` values above ~32700, so larger datasets exported by the segmenter could not be imported to EcoTaxa. Now we just set `img_rank` to `1` for all object images, since we only export one image per object.