### PR TITLE
Use camera-specific ISO calibration for ISO values in dataset metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Calendar Versioning](https://calver.org/) with a `YYYY.minor.patch` scheme.
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
+## v2024.0.1-beta.0 - 2025-04-01
+
+### Fixed
+
+- (Hardware controller) The ISO value stored in dataset metadata now correctly matches the user-set ISO setting, instead of being a constant scaling of the image gain (which is calculated from the user-set ISO according to a camera model-specific scaling factor). This fixes a regression introduced with v2024.0.0-beta.2.
+
 ## v2024.0.0 - 2024-12-25
 
 ### Fixed

--- a/control/adafruithat/planktoscope/imagernew/mqtt.py
+++ b/control/adafruithat/planktoscope/imagernew/mqtt.py
@@ -190,7 +190,7 @@ class Worker(multiprocessing.Process):
         assert (capture_size := self._camera.camera.stream_config.capture_size) is not None
         camera_settings = self._camera.camera.settings
         assert (image_gain := camera_settings.image_gain) is not None
-        calibration = camera.ISO_CALIBRATIONS.get(self._camera._camera.sensor_name, 100)
+        calibration = camera.ISO_CALIBRATIONS.get(self._camera.camera.sensor_name, 100)
         machine_name = identity.load_machine_name()
         metadata = {
             **self._metadata,

--- a/control/adafruithat/planktoscope/imagernew/mqtt.py
+++ b/control/adafruithat/planktoscope/imagernew/mqtt.py
@@ -190,12 +190,13 @@ class Worker(multiprocessing.Process):
         assert (capture_size := self._camera.camera.stream_config.capture_size) is not None
         camera_settings = self._camera.camera.settings
         assert (image_gain := camera_settings.image_gain) is not None
+        calibration = camera.ISO_CALIBRATIONS.get(self._camera._camera.sensor_name, 100)
         machine_name = identity.load_machine_name()
         metadata = {
             **self._metadata,
             "acq_local_datetime": datetime.datetime.now().isoformat().split(".")[0],
             "acq_camera_resolution": f"{capture_size[0]}x{capture_size[1]}",
-            "acq_camera_iso": int(image_gain * 100),
+            "acq_camera_iso": int(image_gain * calibration),
             "acq_camera_shutter_speed": camera_settings.exposure_time,
             "acq_uuid": machine_name,
             "sample_uuid": machine_name,

--- a/control/planktoscopehat/planktoscope/imagernew/mqtt.py
+++ b/control/planktoscopehat/planktoscope/imagernew/mqtt.py
@@ -190,7 +190,7 @@ class Worker(multiprocessing.Process):
         assert (capture_size := self._camera.camera.stream_config.capture_size) is not None
         camera_settings = self._camera.camera.settings
         assert (image_gain := camera_settings.image_gain) is not None
-        calibration = camera.ISO_CALIBRATIONS.get(self._camera._camera.sensor_name, 100)
+        calibration = camera.ISO_CALIBRATIONS.get(self._camera.camera.sensor_name, 100)
         machine_name = identity.load_machine_name()
         metadata = {
             **self._metadata,

--- a/control/planktoscopehat/planktoscope/imagernew/mqtt.py
+++ b/control/planktoscopehat/planktoscope/imagernew/mqtt.py
@@ -190,12 +190,13 @@ class Worker(multiprocessing.Process):
         assert (capture_size := self._camera.camera.stream_config.capture_size) is not None
         camera_settings = self._camera.camera.settings
         assert (image_gain := camera_settings.image_gain) is not None
+        calibration = camera.ISO_CALIBRATIONS.get(self._camera._camera.sensor_name, 100)
         machine_name = identity.load_machine_name()
         metadata = {
             **self._metadata,
             "acq_local_datetime": datetime.datetime.now().isoformat().split(".")[0],
             "acq_camera_resolution": f"{capture_size[0]}x{capture_size[1]}",
-            "acq_camera_iso": int(image_gain * 100),
+            "acq_camera_iso": int(image_gain * calibration),
             "acq_camera_shutter_speed": camera_settings.exposure_time,
             "acq_uuid": machine_name,
             "sample_uuid": machine_name,

--- a/control/pyproject.toml
+++ b/control/pyproject.toml
@@ -2,7 +2,7 @@
 name = "planktoscope-controller"
 # Note: PEP 440 requires pre-releases to be formatted like "2023.7.0b0" rather than
 # "2023.7.0-beta.0", which is different from the Semantic Versioning schema
-version = "2024.0.0"
+version = "2024.0.1b0"
 description = "Controller of PlanktoScope hardware"
 # For simplicity, we follow the definition of "Maintainer" from
 # https://opensource.guide/how-to-contribute/#anatomy-of-an-open-source-project , which says:


### PR DESCRIPTION
This PR fixes a regression introduced in PR #48 in which the value of the ISO metadata field (such as in the metadata exported to EcoTaxa) no longer corresponded with the user-set ISO setting, but instead was a constant scaling of the image gain (which PR #48 changed to be calculated from the ISO setting based on a scaling factor specific to the camera model, instead of a constant scaling of the ISO setting).

This PR also bumps the version number for a v2024.0.1-beta.0 hotfix beta prerelease.