### PR TITLE
light: Cleanup for PlanktoScope hat

### DIFF
--- a/control/planktoscopehat/planktoscope/light.py
+++ b/control/planktoscopehat/planktoscope/light.py
@@ -22,10 +22,6 @@ import enum
 
 logger.info("planktoscope.light is loaded")
 
-print(RPi.GPIO.OUT)
-print(RPi.GPIO.HIGH)
-
-
 class i2c_led:
     """
     LM36011 Led controller
@@ -57,7 +53,7 @@ class i2c_led:
         RPi.GPIO.setwarnings(False)
         RPi.GPIO.setmode(RPi.GPIO.BCM)
         RPi.GPIO.setup(self.LED_PIN, RPi.GPIO.OUT)
-        # RPi.GPIO.output(self.LED_PIN, RPi.GPIO.HIGH)
+        RPi.GPIO.output(self.LED_PIN, RPi.GPIO.HIGH)
         self.on = False
         try:
             self.force_reset()
@@ -223,20 +219,19 @@ class LightProcess(multiprocessing.Process):
         if last_message:
             if "action" in last_message:
                 action = last_message["action"]
-                # TODO: Consider renaming on and off to light_on and light_off
                 if action == "on":
                     # {"action":"on"}
                     logger.info("Turning the light on.")
                     self.led_on()
                     self.light_client.client.publish(
-                        "status/light", '{"status":"Led: On"}'
+                        "status/light", '{"status":"On"}'
                     )
                 elif action == "off":
                     # {"action":"off"}
                     logger.info("Turn the light off.")
                     self.led_off()
                     self.light_client.client.publish(
-                        "status/light", '{"status":"Led: Off"}'
+                        "status/light", '{"status":"Off"}'
                     )
                 else:
                     logger.warning(


### PR DESCRIPTION
# What

Cleanup and remove multi leds support for PlanktoScope hat 

# Why

We want to switch to gpiozero for https://github.com/PlanktoScope/PlanktoScope/issues/323

In the process of starting work on that, I noticed a bunch of unnecessary complexity in `light.py`

* "dead" code (unused)
* multi led support (unused)

# Test

Tested on a PlanktoScope v2.6 with bookworm-dx image

Here is the result when checking out this branch in `/home/pi/device-backend` and rebooting:

The flow was modified locally but it's compatible with the existing one. I will open a follow up PR for the flow

[Screencast From 2025-04-03 16-46-46.webm](https://github.com/user-attachments/assets/e00f7f83-2c8b-4197-924c-66531e53ea0d)
